### PR TITLE
Update 9.1.4.3 Kontraste von Texten ausreichend.adoc

### DIFF
--- a/Prüfschritte/de/9.1.4.3 Kontraste von Texten ausreichend.adoc
+++ b/Prüfschritte/de/9.1.4.3 Kontraste von Texten ausreichend.adoc
@@ -13,13 +13,6 @@ Wenn Vordergrund- und Hintergrundfarbe sich in der Helligkeit ähneln, haben
 sie unter Umständen zu wenig Kontrast, wenn sie mit Schwarzweiß-Monitoren oder
 von Menschen mit verschiedenen Arten von Farbenschwäche betrachtet werden.
 
-Die Ausgabe einer kontrastreicheren Seite durch einen Styleswitcher sollte nicht
-dazu führen, dass die Standardseite sich nicht mehr um nutzbare Kontraste
-kümmert.
-Denn viele Nutzer nehmen das Schaltelement Styleswitcher nicht wahr,
-verstehen die Funktion nicht, oder möchten die Seite lieber im Ausgangszustand
-nutzen.
-
 == Wie wird geprüft?
 
 === 1. Anwendbarkeit des Prüfschritts


### PR DESCRIPTION
Absatz zum wünschenswerten Kontrast der Default-Seite bei Anbieten einer kontrastreicheren Ansicht über Styleswitcher gelöscht, da missverständlich.