### PR TITLE
Update 9.1.1.1a Alternativtexte für Bedienelemente.adoc

### DIFF
--- a/Prüfschritte/de/9.1.1.1a Alternativtexte für Bedienelemente.adoc
+++ b/Prüfschritte/de/9.1.1.1a Alternativtexte für Bedienelemente.adoc
@@ -109,7 +109,7 @@ verwendet wurde (nicht ``display:none``).
   Das passiert, wenn sie als Hintergrundbilder eingebunden sind.
 . Falls nicht redundante grafische Bedienelemente als Hintergrundbilder
   eingebunden sind: Prüfen, ob das Hintergrundbild einen tatsächlich im
-  HTML-Dokument vorhandenen Textlink ersetzt.
+  HTML-Dokument vorhandenen Textlink ersetzt oder ein aussagekräftiger Alternativtext auf andere Art hinterlegt ist (z.B. als ``aria-label`` oder ``title`` auf dem Link).
 . Wenn ein leeres ``a``-Element ohne
   eingeschlossenen Text durch ein Hintergrundbild ersetzt wird, ist dies wie ein
   nicht vorhandenes oder leeres ``alt``-Attribut zu werten.


### PR DESCRIPTION
Da die AGWG  mehrheitlich die Erfüllung von 1.1.1 über title akzeptiert (siehe https://github.com/w3c/wcag/issues/867 ) habe ich die Prüfung von Hintergrundbildern um die Erfüllung über title (und auch aria-label) ergänzt.
Im Schritt 2.1. "Anzeige der Alternativtexte von Grafiken" wird zurzeit nicht explizit das alt-Attribut verlangt, dehalb habe ich den Text hier unverändert gelassen. Man könnte hier noch hinzufügen, dass dies am besten durch das alt-Attribut geschieht, aber auch andere Techniken möglich sind.