### PR TITLE
Update 6.2.2.3 Sprecheridentifizierung.adoc

### DIFF
--- a/Prüfschritte/de/6.2.2.3 Sprecheridentifizierung.adoc
+++ b/Prüfschritte/de/6.2.2.3 Sprecheridentifizierung.adoc
@@ -2,40 +2,33 @@
 include::include/author.adoc[]
 include::include/attributes.adoc[]
 
-== Grundlage des Prüfschritts
-
-Grundlage des Prüfschritts ist die Tabelle A.1 im Annex A der EN 301 549
-V3.1.1.
-In dieser Tabelle wird auf Abschnitt
-6.2.2 "Display of RTT" verwiesen.
-
 == Was wird geprüft?
 
-Wenn die Web-App Echtzeit Textkommunikation unterstützt und den
-aktiven Sprecher über Sprache identifiziert, sollen auch Sprecher, die
-Echtzeit-Texteingaben nutzen, gleichermaßen identifizierbar sein.
+Wenn die Web-Anwendung Echtzeit Textkommunikation (RTT, Real-time Text) unterstützt und den aktiven Sprecher über Sprache identifiziert, sollen auch Sprecher, die Echtzeit-Texteingaben nutzen, gleichermaßen identifizierbar sein.
 
 == Wie wird geprüft?
 
-=== Anwendbarkeit des Prüfschritts
+=== 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist anwendbar, wenn die Web-App Echtzeit Textkommunikation
-unterstützt und den aktiven Sprecher über Sprache identifiziert.
-Der aktive Sprecher wird dabei in der Web-App markiert oder anderweitig
-hervorgehoben.
+Der Prüfschritt ist anwendbar, wenn die Web-Anwendung Echtzeit-Textkommunikation (RTT, Real-time Text) unterstützt und den aktiven Sprecher über Sprache identifiziert. Der aktive Sprecher wird dabei in der Web-App markiert oder anderweitig hervorgehoben.
 
-=== Prüfung
+=== 2. Prüfung
 
-. Web-App öffnen
-. Prüfen, ob der aktive Sprecher über Sprache identifiziert und in der App
-  markiert oder anderweitig hervorgehoben wird
-. Ist dies der Fall, prüfen, ob auch Teilnehmer, die Echtzeit-Texteingabe verwenden, beim Eingaben markiert oder anderweitig hervorgehoben werden
+. Web-App öffnen.
+. Prüfen, ob der aktive Sprecher über Sprache identifiziert und in der App markiert oder anderweitig hervorgehoben wird.
+. Ist dies der Fall, prüfen, ob auch Teilnehmer, die Echtzeit-Texteingabe verwenden, beim Eingaben markiert oder anderweitig hervorgehoben werden.
 
-==== Hinweise
+=== 3. Hinweise
 
-Bei diesem Test muss eine Video- und Sprachverbindung mit mehreren Teilnehmern
-etabliert werden, um eine eventuelle Markierung oder anderweitige Hervorhebung
+Bei diesem Test muss eine Video- und Sprachverbindung mit mehreren Teilnehmern etabliert werden, um eine eventuelle Markierung oder anderweitige Hervorhebung
 zweifelsfrei festzustellen.
+
+== Einordnung des Prüfschritts
+
+=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1
+
+* 6.2.2 Display of RTT
+
 
 == Quellen
 

--- a/Prüfschritte/de/6.2.2.3 Sprecheridentifizierung.adoc
+++ b/Prüfschritte/de/6.2.2.3 Sprecheridentifizierung.adoc
@@ -11,35 +11,30 @@ In dieser Tabelle wird auf Abschnitt
 
 == Was wird geprüft?
 
-Wenn die Web-App Echtzeit Textkommunikation senden und empfangen kann und den
+Wenn die Web-App Echtzeit Textkommunikation unterstützt und den
 aktiven Sprecher über Sprache identifiziert, sollen auch Sprecher, die
-Echtzeit-Textkommunikation nutzen, identifiziert und beim Kommunizieren
-vergleichbar angezeigt
-werden.
+Echtzeit-Texteingaben nutzen, gleichermaßen identifizierbar sein.
 
 == Wie wird geprüft?
 
 === Anwendbarkeit des Prüfschritts
 
 Der Prüfschritt ist anwendbar, wenn die Web-App Echtzeit Textkommunikation
-senden und empfangen kann und den aktiven Sprecher über Sprache identifiziert.
+unterstützt und den aktiven Sprecher über Sprache identifiziert.
 Der aktive Sprecher wird dabei in der Web-App markiert oder anderweitig
 hervorgehoben.
 
 === Prüfung
 
 . Web-App öffnen
-. prüfen, ob die Web-App das Senden und Empfangen von Echtzeit
-  Textkommunikation anbietet
-. prüfen, ob der aktive Sprecher über Sprache identifiziert und in der App
+. Prüfen, ob der aktive Sprecher über Sprache identifiziert und in der App
   markiert oder anderweitig hervorgehoben wird
-. ist dies der Fall, prüfen, ob auch Teilnehmer die Echtzeit-Textkommunikation
-  nutzen, beim Kommunizieren markiert oder anderweitig hervorgehoben werden
+. Ist dies der Fall, prüfen, ob auch Teilnehmer, die Echtzeit-Texteingabe verwenden, beim Eingaben markiert oder anderweitig hervorgehoben werden
 
 ==== Hinweise
 
 Bei diesem Test muss eine Video- und Sprachverbindung mit mehreren Teilnehmern
-etabliert werden um eine eventuelle Markierung oder anderweitige Hervorhebung
+etabliert werden, um eine eventuelle Markierung oder anderweitige Hervorhebung
 zweifelsfrei festzustellen.
 
 == Quellen

--- a/Prüfschritte/de/6.2.2.3 Sprecheridentifizierung.adoc
+++ b/Prüfschritte/de/6.2.2.3 Sprecheridentifizierung.adoc
@@ -20,8 +20,7 @@ Der Prüfschritt ist anwendbar, wenn die Web-Anwendung Echtzeit-Textkommunikatio
 
 === 3. Hinweise
 
-Bei diesem Test muss eine Video- und Sprachverbindung mit mehreren Teilnehmern etabliert werden, um eine eventuelle Markierung oder anderweitige Hervorhebung
-zweifelsfrei festzustellen.
+Bei diesem Test muss eine Video- und Sprachverbindung mit mehreren Teilnehmern etabliert werden, um eine eventuelle Markierung oder anderweitige Hervorhebung zweifelsfrei festzustellen.
 
 == Einordnung des Prüfschritts
 


### PR DESCRIPTION
Schritt "prüfen, ob die Web-App das Senden und Empfangen von Echtzeit
  Textkommunikation anbietet" entfernt, da er schon in Anwendbarkeit des Prüfschrtts enthalten ist.