### PR TITLE
Update 5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc

### DIFF
--- a/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
+++ b/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
@@ -58,7 +58,7 @@ Bedienelemente der Barrierefreiheitsfunktion oder die Funktion selbst verstoßen
 
 == Einordnung des Prüfschritts
 
-=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1 Annex A
+=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1
 
 5.2 "Activation of accessibility features".
 

--- a/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
+++ b/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
@@ -2,13 +2,6 @@
 include::include/author.adoc[]
 include::include/attributes.adoc[]
 
-== Grundlage des Prüfschritts
-
-Grundlage des Prüfschritts ist die Tabelle A.1 im Annex A der EN 301 549
-V3.1.1.
-In dieser Tabelle wird auf Abschnitt
-5.2 "Activation of accessibility features" verwiesen.
-
 == Was wird geprüft?
 
 Wenn die Webseite Funktionen für die Barrierefreiheit bereithält, die
@@ -20,46 +13,44 @@ sie unterstützen soll, selbstständig aktivierbar sein soll.
 Beispiele für Barrierefreiheitsfunktionen:
 
 * Vorlesefunktion
-* Kontrasterhöhung, Farbschemata
-* Schriftgröße, Schriftformatierungen (z. B. Zeilenabstand, Schriftart usw.)
-* Leichte Sprache
-* Deutsche Gebärdensprache
-* Animationen / automatische Audios pausieren
+* Kontrasterhöhung, abweichende Farbschemata
+* Anpassung der Schriftgröße, Schriftformatierungen (z. B. Zeilenabstand, Schriftart usw.)
+* Versionen in Leichter Sprache oder Deutscher Gebärdensprache
+* Einstellungen zum Deaktivieren automatischen Abspielens be Animationen, Videos oder Audio
 
 == Wie wird geprüft?
 
 === Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist anwendbar, wenn die zu prüfende Webseite Funktionen für die
-Barrierefreiheit bereithält.
-Dieser Prüfschritt ist explizit nicht auf systemseitige Bedienungshilfen
-anzuwenden (z. B. vom Browser oder Betriebssystem).
+Der Prüfschritt ist anwendbar, wenn die zu prüfende Webseite spezielle Barrierefreiheits-Funktionen bereithält (hierfür müssen bei Webanwendungen auch die Einstellungen der Web-App überprüft werden).
+Nicht berücksichtigt werden systemseitige Bedienungshilfen (z. B. vom Browser oder Betriebssystem).
 
 === Prüfung
 
-. Webseite öffnen
-. prüfen, ob Barrierefreiheitsfunktionen auf den zu testenden Seiten
-  angeboten werden
-. Falls es sich um eine komplexere Web-Anwendung handelt, Einstellungen der
-  Web-App aufrufen und auch dort nach entsprechenden Funktionen suchen
-. falls Barrierefreiheitsfunktionen angeboten werden:
+. Webseite aufrufen.
+. Falls Barrierefreiheitsfunktionen angeboten werden:
 +
-  * Ist die Funktion für die Zielgruppe deutlich identifizierbar? Siehe
-    <<Hinweis zur Identifizierbarkeit>>.
-  * Ist die Funktion für die Zielgruppe selbstständig aktivierbar?
+  * Ist die Barrierefreiheits-Funktion für die Zielgruppe identifizierbar?
+  * Ist die Barrierefreiheits-Funktion für die Zielgruppe selbstständig aktivierbar?
 
-==== Hinweis zur Identifizierbarkeit
+=== Hinweise
 
-Die Barrierefreiheitsfunktionen müssen insbesondere für deren Zielgruppen
-identifizierbar sein.
-Dazu erfüllen die Barrierefreiheitsfunktionen bzw. die zugehörigen
-Bedienelemente alle auf sie anwendbaren Prüfschritte, z. B.:
+==== Hinweis zur Bestimmung der Zielgruppe der Barrierefreiheits-Funktion
 
-* Alternativtexte
-* Tastaturbedienbarkeit, sichtbarer Fokus
-* Kontrast
-* Vergrößerung
-* Name, Rolle, Wert
+Viele Menschen mit Behinderung nutzen verschieden Eingabemöglichkeiten, z.B. fallweise die Maus oder die Tastatur. Menschen mit kognitiven Einschränkungen haben zum Teil auch andere Einschränkungen. Bei der Bestimmung der Zielgruppe ist es deshalb wichtig, auch Anforderungen zu berücksichtigen, die nicht direkt mit der Einschränkung zu tun haben, für die die Barrierefreiheits-Funktion gedacht ist.
+
+==== Hinweis zur Identifizierbarkeit und Aktivierbarkeit
+
+Bedienelemente für Barrierefreiheits-Funktionen sollen grundsätzlich alle Barrierefreiheits-Anforderungen erfüllen. Zwei Beispiele:
+
+. Ein Schalter zum Laden einer Version in Leichter Sprache sollte leicht verständlich, kontrastreich und zugänglich beschriftet sein, denn es gibt Menschen mit kognitiven Einschränkungen, die außerdem sehbehindert oder blind sind.
+. Ein Kontrastmodus für Menschen mit Sehbehinderung braucht eine zugängliche Beschriftung, die ihn auch für Screenreader-Nutzer identifizierbar macht, denn manche sehbehinderte Menschne nutzen auch den Screenreader. 
+
+== Einordnung des Prüfschritts
+
+=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1 Annex A
+
+5.2 "Activation of accessibility features".
 
 == Quellen
 

--- a/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
+++ b/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
@@ -46,6 +46,16 @@ Bedienelemente für Barrierefreiheits-Funktionen sollen grundsätzlich alle Barr
 . Ein Schalter zum Laden einer Version in Leichter Sprache sollte leicht verständlich, kontrastreich und zugänglich beschriftet sein, denn es gibt Menschen mit kognitiven Einschränkungen, die außerdem sehbehindert oder blind sind.
 . Ein visueller Kontrastmodus-Schalter für Menschen mit Sehbehinderung braucht auch eine zugängliche Beschriftung, denn manche sehbehinderte Menschen nutzen auch den Screenreader. 
 
+=== 4. Bewertung
+
+==== Erfüllt:
+
+Die Barrierefreiheits-Funktion ist barrierefrei identifizierbar und aktivierbar.
+
+==== Nicht erfüllt:
+
+Bedienelemente der Barrierefreiheitsfunktion oder die Funktion selbst verstoßen gegen Anforderungen der EN.
+
 == Einordnung des Prüfschritts
 
 === Einordnung des Prüfschritts nach EN 301 549 V3.1.1 Annex A

--- a/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
+++ b/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
@@ -20,12 +20,12 @@ Beispiele für Barrierefreiheitsfunktionen:
 
 == Wie wird geprüft?
 
-=== Anwendbarkeit des Prüfschritts
+=== 1. Anwendbarkeit des Prüfschritts
 
 Der Prüfschritt ist anwendbar, wenn die zu prüfende Webseite spezielle Barrierefreiheits-Funktionen bereithält (hierfür müssen bei Webanwendungen auch die Einstellungen der Web-App überprüft werden).
 Nicht berücksichtigt werden systemseitige Bedienungshilfen (z. B. vom Browser oder Betriebssystem).
 
-=== Prüfung
+=== 2. Prüfung
 
 . Webseite aufrufen.
 . Falls Barrierefreiheitsfunktionen angeboten werden:
@@ -33,13 +33,13 @@ Nicht berücksichtigt werden systemseitige Bedienungshilfen (z. B. vom Browser 
   * Ist die Barrierefreiheits-Funktion für die Zielgruppe identifizierbar?
   * Ist die Barrierefreiheits-Funktion für die Zielgruppe selbstständig aktivierbar?
 
-=== Hinweise
+=== 3. Hinweise
 
-==== Hinweis zur Bestimmung der Zielgruppe der Barrierefreiheits-Funktion
+==== 3.1 Hinweis zur Bestimmung der Zielgruppe der Barrierefreiheits-Funktion
 
 Viele Menschen mit Behinderung nutzen verschieden Eingabemöglichkeiten, z.B. fallweise die Maus oder die Tastatur. Menschen mit kognitiven Einschränkungen haben zum Teil auch andere Einschränkungen. Bei der Bestimmung der Zielgruppe ist es deshalb wichtig, auch Anforderungen zu berücksichtigen, die nicht direkt mit der Einschränkung zu tun haben, für die die Barrierefreiheits-Funktion gedacht ist.
 
-==== Hinweis zur Identifizierbarkeit und Aktivierbarkeit
+==== 3.2 Hinweis zur Identifizierbarkeit und Aktivierbarkeit
 
 Bedienelemente für Barrierefreiheits-Funktionen sollen grundsätzlich alle Barrierefreiheits-Anforderungen erfüllen. Zwei Beispiele:
 

--- a/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
+++ b/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
@@ -52,7 +52,7 @@ Bedienelemente für Barrierefreiheits-Funktionen sollen grundsätzlich alle Barr
 
 Die Barrierefreiheits-Funktion ist barrierefrei identifizierbar und aktivierbar.
 
-==== Nicht erfüllt:
+==== Nicht voll erfüllt:
 
 Bedienelemente der Barrierefreiheitsfunktion oder die Funktion selbst verstoßen gegen Anforderungen der EN.
 

--- a/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
+++ b/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
@@ -44,7 +44,7 @@ Viele Menschen mit Behinderung nutzen verschieden Eingabemöglichkeiten, z.B. fa
 Bedienelemente für Barrierefreiheits-Funktionen sollen grundsätzlich alle Barrierefreiheits-Anforderungen erfüllen. Zwei Beispiele:
 
 . Ein Schalter zum Laden einer Version in Leichter Sprache sollte leicht verständlich, kontrastreich und zugänglich beschriftet sein, denn es gibt Menschen mit kognitiven Einschränkungen, die außerdem sehbehindert oder blind sind.
-. Ein Kontrastmodus für Menschen mit Sehbehinderung braucht eine zugängliche Beschriftung, die ihn auch für Screenreader-Nutzer identifizierbar macht, denn manche sehbehinderte Menschne nutzen auch den Screenreader. 
+. Ein visueller Kontrastmodus-Schalter für Menschen mit Sehbehinderung braucht auch eine zugängliche Beschriftung, denn manche sehbehinderte Menschen nutzen auch den Screenreader. 
 
 == Einordnung des Prüfschritts
 


### PR DESCRIPTION
Änderungen:
- Anpassung an die übliche Struktur (noch nicht abgeschlossen)
- Hinweis zur Bestimmung der Zielgruppe
- Hinweis, was Identifizierbarkeit und Aktivierbarkeit praktisch bedeutet, mit zwei Beispielen
- Suche nach Barrierefreiheitsfunktionen aus Prüfanleitung entfernt (dafür in Anwendbarkeit explizit gemacht)

Hinweis / Frage: Die Formulierung in der EN deutet darauf hin, dass man nur Barrierefreiheit für "spezielle Bedürfnisse" prüft - ein Schalter für Leichte Sprache bräuchte ggf. keinen Alternativtext, "weil das ja nicht für die Blinden ist". Evtl. schießen wir also mit der Forderung "Bedienelemente erfüllen alle Anforderungen" über das intendierte Ziel dieser Anforderung hinaus.