### PR TITLE
12.1.2 Änderung Prüfanleitung

### DIFF
--- a/Prüfschritte/de/12.1.2 Barrierefreie Dokumentation.adoc
+++ b/Prüfschritte/de/12.1.2 Barrierefreie Dokumentation.adoc
@@ -27,13 +27,14 @@ Die Prüfung der Barrierefreiheit von nicht-web-basierter Dokumentation (etwa vo
 
 === 2. Prüfung
 
-. Wenn vorhanden, muss die Erklärung zu Barrierefreiheit Teil der Seitenauswahl sein.
-. Wenn weitere web-basierte Dokumentation zum Web-Angebot vorhanden ist, soll auch diese in die Seitenauswahl einbezogen werden.
-. Wenn sämtliche anwendbaren Prüfschritte des Verfahrens konform sind, ist auch dieser Prüfschritt konform.
+. Prüfen, ob sämtliche anwendbaren Prüfschritte des Verfahrens mit konform bewertet worden sind.
+. Ist dies der Fall, ist auch dieser Prüfschritt konform.
 
 === 3. Hinweise
 
-Der Prüfschritt schließt nicht die Möglichkeit aus, alternative Formate anzubieten, die die Bedürfnisse einer bestimmten Nutzergruppe erfüllen (z. B. Braille-Dokumente für blinde Menschen oder Informationen in leichter Sprache  für Personen mit eingeschränkter Kognition, Sprache und Lernfähigkeit).
+- Wenn vorhanden, muss die Erklärung zu Barrierefreiheit Teil der Seitenauswahl sein.
+- Wenn weitere web-basierte Dokumentation zum Web-Angebot vorhanden ist, soll auch diese in die Seitenauswahl einbezogen werden.
+- Der Prüfschritt schließt nicht die Möglichkeit aus, alternative Formate anzubieten, die die Bedürfnisse einer bestimmten Nutzergruppe erfüllen (z. B. Braille-Dokumente für blinde Menschen oder Informationen in leichter Sprache  für Personen mit eingeschränkter Kognition, Sprache und Lernfähigkeit).
 
 Für weitere Hinweise zu diesem Prüfschritt können Sie auf GitHub https://github.com/BIK-BITV/BIK-Web-Test/issues[ein Issue eröffnen].
 


### PR DESCRIPTION
Änderung Prüfanleitung:
Hinweise zur Seitenauswahl gehören meiner Ansicht nach nicht in die Prüfanleitung, da die Seitenauswahl während der Prüfung bereits abgeschlossen ist. 
Daher habe ich entsprechende Texte in den Abschnitt "Hinweise" geschoben. Es verbleibt, die Prüfung ob im Verfahren für die Dokumentation alle Prüfschritte mit konform bewertet worden sind.

Es ist davon auszugehen, dass wenn die Seitenauswahl entsprechend des Prüfverfahrens durchgeführt wurde, die Dokumentation Teil der Seitenauswahl ist.