### PR TITLE
Update 12.2.2 Technischer Support.adoc

### DIFF
--- a/Prüfschritte/de/12.2.2 Technischer Support.adoc
+++ b/Prüfschritte/de/12.2.2 Technischer Support.adoc
@@ -24,8 +24,8 @@ Der Prüfschritt ist anwendbar, wenn das Webangebot in seiner Dokumentation Info
 
 === 2. Prüfung
 
-. Den technischen Support kontaktieren und stichprobenartig Fragen zu den in der FDokumentation genannten Barrierefreiheits-Funktionen oder zur Hilfsmittel-Kompatibilität stellen.
-. Werden mündlich oder über die Versendung zusätzlicher Informationen Hilfestellungen gegeben?
+. Den technischen Support kontaktieren und stichprobenartig Fragen zu den in der Dokumentation genannten Barrierefreiheits-Funktionen oder zur Hilfsmittel-Kompatibilität stellen.
+. Ist der technische Support in der Lage, mündlich oder schriftlich zusätzliche Informationen und Hilfestellungen gegeben?
 
 === 3. Hinweise
 

--- a/Prüfschritte/de/12.2.2 Technischer Support.adoc
+++ b/Prüfschritte/de/12.2.2 Technischer Support.adoc
@@ -4,17 +4,17 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Der technische Support (über Telefon, Mail, ...) soll Informationen zur
-Barrierefreiheit und Kompatibilität zu assistiven Technologien bereitstellen
-können, die die Webanwendung betreffen.
-Dies soll mindestens die Informationen umfassen, die dazu in der
-Dokumentation der Webanwendung erwähnt werden (siehe auch Prüfschritt
+Der technische Support (über Telefon, Mail, ...) soll Informationen zur Barrierefreiheit und Kompatibilität zu assistiven Technologien bereitstellen können, die die Webanwendung betreffen. Dies soll mindestens die Informationen umfassen, die dazu in der Dokumentation der Webanwendung erwähnt werden (siehe auch Prüfschritt
 ifdef::env_embedded[12.1.1 "Dokumentation von Kompatibilität und Barrierefreiheit"]
 ifndef::env_embedded[]
   <<12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc#,
   12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit>>
 endif::env_embedded[]
 ).
+
+== Warum wir das geprüft?
+
+Hinweise zu Barrierefreiheits-Funktionen sind nicht immer verständlich genug. Solche zur Hilfsmittelkompatibilität in der Dokumentation können schnell veraltet sein. Es ist wichtig, dass der technische Support auf Kunden-Fragen eingehen und Hilfe bereitstellen kann.
 
 == Wie wird geprüft?
 

--- a/Prüfschritte/de/12.2.2 Technischer Support.adoc
+++ b/Prüfschritte/de/12.2.2 Technischer Support.adoc
@@ -20,26 +20,18 @@ endif::env_embedded[]
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist immer anwendbar.
+Der Prüfschritt ist anwendbar, wenn das Webangebot in seiner Dokumentation Informationen zu Barrierefreiheits-Funktionen oder zur Hilfsmittel-Kompatibilität bereitstellt.
 
 === 2. Prüfung
 
-Zielführend könnte es bspw. sein, anhand der Informationen aus der
-Dokumentation der Webanwendung, den technischen Support zu kontaktieren und einige
-Fragen zur Barrierefreiheit stichprobenartig zu stellen.
-
-Falls möglich, können auch die Dokumente, die dem technischem Support zur
-Verfügung stehen, stichprobenartig geprüft werden.
-
-Verbreitet sollten jedoch Assistenzsysteme sein, die den Support-Mitarbeiter
-durch die Problemlösung führt.
-Es ist sehr fraglich, ob ein Prüfer zu diesen Systemen Zugang für eine Prüfung
-bekommen würde.
+. Den technischen Support kontaktieren und stichprobenartig Fragen zu den in der FDokumentation genannten Barrierefreiheits-Funktionen oder zur Hilfsmittel-Kompatibilität stellen.
+. Werden mündlich oder über Versendung zusätzlicher Informationen Hilfestellungen gegeben?
 
 === 3. Hinweise
 
-Wie dieser Prüfschritt in der Praxis getestet werden kann, ist noch nicht
-vollständig geklärt.
+Der Prüfschritt bewertet nicht die Qualität gegebener Information und auch nicht die Zugänglichkeit von Übersandten Dokumenten. Er prüft lediglich, ob der technische Support des Anbieters darauf eingerichtet ist, mit weitergehenden Fragen zu Barrierefreiheits-Funktionen oder  Hilfsmittel-Kompatibilität unzugehen.
+
+Wie dieser Prüfschritt in der Praxis getestet werden kann, ist noch nicht vollständig geklärt.
 Hinweise dazu können Sie in einem GitHub https://github.com/BIK-BITV/BIK-Web-Test/issues[Issue hinterlassen].
 
 == Einordnung des Prüfschritts
@@ -48,6 +40,12 @@ Hinweise dazu können Sie in einem GitHub https://github.com/BIK-BITV/BIK-Web-Te
 
 12.2.2 Information on accessibility and compatibility features
 
+=== Abgrenzung zu anderen Prüfschritten
+
+In diesem Prüfschritt wird ermittelt, ob der technische Support zu dokumentierten Barrierefreiheits-Funktionen oder zur Hilfsmittelkompatibilität weitere Informationen liefern kann. Davon ist abzugrenzen:
+
+* Der Prüfschritt 12.2.3 "Effektive Kommunikation" prüft, ob mit dem Support auf verschiedene Weise kommuniziert werfen kann (z.B: per Telefon, Kontaktformular, E-Mail oder Chat).
+* Der Prüfschritt 12.2.4 "Vom Support bereitgestellte Dokumentation" prüft die Barrierefreiheit der vom Support bereitgestellten web-basierten Dokumentation.
 
 == Quellen
 

--- a/Prüfschritte/de/12.2.2 Technischer Support.adoc
+++ b/Prüfschritte/de/12.2.2 Technischer Support.adoc
@@ -14,7 +14,7 @@ endif::env_embedded[]
 
 == Warum wir das geprüft?
 
-Hinweise zu Barrierefreiheits-Funktionen sind nicht immer verständlich genug. Solche zur Hilfsmittelkompatibilität in der Dokumentation können schnell veraltet sein. Es ist wichtig, dass der technische Support auf Kunden-Fragen eingehen und Hilfe bereitstellen kann.
+Hinweise zu Barrierefreiheits-Funktionen sind nicht immer verständlich genug. Hinweise zur Hilfsmittel-Kompatibilität können schnell veraltet sein. Es ist wichtig, dass der technische Support auf Kunden-Fragen eingehen und Hilfe bereitstellen kann.
 
 == Wie wird geprüft?
 
@@ -25,14 +25,13 @@ Der Prüfschritt ist anwendbar, wenn das Webangebot in seiner Dokumentation Info
 === 2. Prüfung
 
 . Den technischen Support kontaktieren und stichprobenartig Fragen zu den in der FDokumentation genannten Barrierefreiheits-Funktionen oder zur Hilfsmittel-Kompatibilität stellen.
-. Werden mündlich oder über Versendung zusätzlicher Informationen Hilfestellungen gegeben?
+. Werden mündlich oder über die Versendung zusätzlicher Informationen Hilfestellungen gegeben?
 
 === 3. Hinweise
 
-Der Prüfschritt bewertet nicht die Qualität gegebener Information und auch nicht die Zugänglichkeit von Übersandten Dokumenten. Er prüft lediglich, ob der technische Support des Anbieters darauf eingerichtet ist, mit weitergehenden Fragen zu Barrierefreiheits-Funktionen oder  Hilfsmittel-Kompatibilität unzugehen.
+Der Prüfschritt bewertet nicht die Qualität der übermittelten Information und auch nicht die Zugänglichkeit von Übersandten Dokumenten. Er prüft lediglich, ob der technische Support des Anbieters darauf eingerichtet ist, mit weitergehenden Fragen zu Barrierefreiheits-Funktionen oder Hilfsmittel-Kompatibilität unzugehen.
 
-Wie dieser Prüfschritt in der Praxis getestet werden kann, ist noch nicht vollständig geklärt.
-Hinweise dazu können Sie in einem GitHub https://github.com/BIK-BITV/BIK-Web-Test/issues[Issue hinterlassen].
+Wie dieser Prüfschritt in der Praxis getestet werden kann, ist noch nicht vollständig geklärt. Hinweise dazu können Sie in einem GitHub https://github.com/BIK-BITV/BIK-Web-Test/issues[Issue hinterlassen].
 
 == Einordnung des Prüfschritts
 
@@ -42,9 +41,9 @@ Hinweise dazu können Sie in einem GitHub https://github.com/BIK-BITV/BIK-Web-Te
 
 === Abgrenzung zu anderen Prüfschritten
 
-In diesem Prüfschritt wird ermittelt, ob der technische Support zu dokumentierten Barrierefreiheits-Funktionen oder zur Hilfsmittelkompatibilität weitere Informationen liefern kann. Davon ist abzugrenzen:
+In diesem Prüfschritt wird ermittelt, ob der technische Support zu dokumentierten Barrierefreiheits-Funktionen oder zur Hilfsmittel-Kompatibilität weitere Informationen liefern kann. Davon ist abzugrenzen:
 
-* Der Prüfschritt 12.2.3 "Effektive Kommunikation" prüft, ob mit dem Support auf verschiedene Weise kommuniziert werfen kann (z.B: per Telefon, Kontaktformular, E-Mail oder Chat).
+* Der Prüfschritt 12.2.3 "Effektive Kommunikation" prüft, ob mit dem technischen Support auf verschiedene Weise kommuniziert werfen kann (z.B. per Telefon, Kontaktformular, E-Mail oder Chat).
 * Der Prüfschritt 12.2.4 "Vom Support bereitgestellte Dokumentation" prüft die Barrierefreiheit der vom Support bereitgestellten web-basierten Dokumentation.
 
 == Quellen


### PR DESCRIPTION
- Anwendbarkeit ist nun begrenzt auf Angebote, die überhaupt Dokumentation zu Barrierefreiheits-Funktionen oder Hilfsmittel-Kompatibilität haben
- Hinzufügung von "Warum wird das geprüft?"
- Vereinfachung der Prüfung
- Abgrenzung des Prüfschritts von den Prüfungen in 12.2.3 und 12.2.4 
