### PR TITLE
Update 7.1.1 Wiedergabe von Untertiteln.adoc

### DIFF
--- a/Prüfschritte/de/7.1.1 Wiedergabe von Untertiteln.adoc
+++ b/Prüfschritte/de/7.1.1 Wiedergabe von Untertiteln.adoc
@@ -21,7 +21,7 @@ Damit closed captions (dynamisch zuschaltbare Untertitel) von den Nutzenden wahr
 
 === 1. Anwendbarkeit des Prüfschritts
 
-*	Der Prüfschritt ist anwendbar, die  Webseite aufgezeichnete Videos mit synchroner Bild- und Tonspur abspielt und Untertitel zuschaltbar sind. Die Untertitel sind dann in der Regel innerhalb des ``video``-Elements als getrennte ``track``-Datei verfügbar.
+*	Der Prüfschritt ist anwendbar, wenn die  Webseite aufgezeichnete Videos mit synchroner Bild- und Tonspur anbietet und Untertitel zuschaltbar sind. Die Untertitel sind dann in der Regel innerhalb des ``video``-Elements als getrennte ``track``-Datei verfügbar.
 *	Aufgezeichnete Videos ohne Tonspur (stumme Videos) brauchen keine Untertitelung, der Prüfschritt ist für sie nicht anwendbar.
 
 === 2. Prüfung

--- a/Prüfschritte/de/7.1.1 Wiedergabe von Untertiteln.adoc
+++ b/Prüfschritte/de/7.1.1 Wiedergabe von Untertiteln.adoc
@@ -4,7 +4,7 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Sind Videos mit synchroner Bild- und Tonspur vorhanden, bietet der Videoplayer die Möglichkeit, die Untertitel anzuzeigen. Werden dynamisch zuschaltbare,  textbasierte Untertitel (closed captions) angeboten, bietet der Videoplayer die Möglichkeit, diese ein- und auszublenden. 
+Sind Videos mit synchroner Bild- und Tonspur vorhanden und werden  dynamisch zuschaltbare, textbasierte Untertitel (closed captions) angeboten, bietet der Videoplayer die Möglichkeit, diese ein- und auszublenden. 
 
 == Warum wird das geprüft?
 
@@ -21,17 +21,10 @@ Damit closed captions (dynamisch zuschaltbare Untertitel) von den Nutzenden wahr
 
 === 1. Anwendbarkeit des Prüfschritts
 
-*	Der Prüfschritt ist anwendbar, wenn auf der Webseite ein Videoplayer eingebunden ist, der aufgezeichnete Videos mit synchroner Bild- und Tonspur abspielt.
-*	Aufgezeichnete Videos ohne Tonspur, stumme Videos, brauchen keine Untertitelung, der Prüfschritt ist für sie nicht anwendbar.
+*	Der Prüfschritt ist anwendbar, die  Webseite aufgezeichnete Videos mit synchroner Bild- und Tonspur abspielt und Untertitel zuschaltbar sind. Die Untertitel sind dann in der Regel innerhalb des ``video``-Elements als getrennte ``track``-Datei verfügbar.
+*	Aufgezeichnete Videos ohne Tonspur (stumme Videos) brauchen keine Untertitelung, der Prüfschritt ist für sie nicht anwendbar.
 
 === 2. Prüfung
-
-==== 2.1 Anzeigen von open captions
-
-. Das Video wird im auf der Website eingebundenen Videoplayer abgespielt. 
-. Untertitel werden angezeigt (open captions).
-
-==== 2.2 Anzeigen von closed captions
 
 . Text-Dateien für Untertitelungen werden über das HTML 5 `track`-Element eingebunden. Im Quellcode prüfen, ob über das `track`-Element eine Untertitel-Datei eingebunden ist. Das `kind`-Attribut legt die Art der Texteinblendung fest. Der Wert `subtitles` spezifiziert, dass es sich um Untertitel handelt.
 . Wenn eine Untertitel-Datei eingebunden ist, prüfen, ob der Videoplayer eine Möglichkeit bietet, diese ein- und auszublenden.


### PR DESCRIPTION
Änderungen der Anwendbarkeit, Fokussierung des Prüfschritts auf Einbindungen von Videos mit separaten Untertiteln.
Änderung der prüfung, Wegfall der Prüfung vom Open Captions (eingebrannten Untertiteln). Fälle, in denen die Untertitel eingebrannt und immer sichtbar sind, brauchen sie auch nicht zuschaltbar zu sein.