### PR TITLE
Korrektur kleinerer wiederkehrender Tippfehler in Überschriften: z.B.…

### DIFF
--- a/Prüfschritte/de/11.7 Benutzerdefinierte Einstellungen.adoc
+++ b/Prüfschritte/de/11.7 Benutzerdefinierte Einstellungen.adoc
@@ -46,11 +46,11 @@ https://github.com/BIK-BITV/BIK-Web-Test/issues[ein Issue zu diesem Prüfschritt
 
 === 4. Bewertung
 
-==== Erfüllt: 
+==== Erfüllt
 
 * Die Seite wird im Firefox-Browser nach dem Vornehmen von abweichenden Einstellungen (z.B. heller Text auf dunklem Hintergrund) entsprechend anders dargestellt, Schriften erscheinen vergrößert und in der jeweils eingestelten Schrifttype.
 
-==== Nicht voll erfüllt:
+==== Nicht voll erfüllt
  
 * Texte haben bei Nutzung eigener Farbeinstellungen nicht genug Kontrast oder verschwinden
 * Fließtext wird nicht vergrößert dargestellt.

--- a/Prüfschritte/de/11.8.2 Barrierefreie Erstellung von Inhalten.adoc
+++ b/Prüfschritte/de/11.8.2 Barrierefreie Erstellung von Inhalten.adoc
@@ -42,9 +42,9 @@ Umfangreiche Autorenwerkzeuge, wie z. B. Textverarbeitungen können im BITV-Test
 
 Wenn Sie Hinweise zur Ausgestaltung dieses Prüfschritts haben, können Sie auf GitHub https://github.com/BIK-BITV/BIK-Web-Test/issues[ein Issue zu diesem Prüfschritt erstellen].
 
-== Einordnung des Prüfschrtts
+== Einordnung des Prüfschritts
 
-=== Einordnung des Prüfschrtts nach EN 301 549 V3.1.1
+=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1
 
 * 11.8.2 Accessible content creation
 

--- a/Prüfschritte/de/11.8.3 Erhaltung von Barrierefreiheitsinformationen bei Transformation.adoc
+++ b/Prüfschritte/de/11.8.3 Erhaltung von Barrierefreiheitsinformationen bei Transformation.adoc
@@ -47,7 +47,7 @@ https://github.com/BIK-BITV/BIK-Web-Test/issues[ein Issue zu diesem Prüfschritt
 
 == Einordnung des Prüfschritts
 
-=== Einordnung des Prüfschritts nich EN 301 549 V3.1.1
+=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1
 
 11.8.3 Preservation of accessibility information in transformations
 

--- a/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
+++ b/Prüfschritte/de/12.1.1 Dokumentation von Kompatibilität und Barrierefreiheit.adoc
@@ -6,7 +6,7 @@ include::include/attributes.adoc[]
 
 Die Dokumentation des Webangebots soll vorhandene zusätzliche Eigenschaften und Funktionen in Bezug auf Barrierefreiheit auflisten und deren Nutzung erklären, sofern diese als Teil des Web-Angebots selbst implementiert wurden. Dazu gehören zum Beispiel angepasste Ansichten mit geänderten Kontrasten oder Textgrößen, Vorlesefunktionen, oder verfügbare Tastaturkurzbefehle. Auch Informationen zur (möglicherweise eingeschränkten) Kompatibilität mit assistiven Technologien zählen dazu.
 
-== Warum wir das geprüft?
+== Warum wird das geprüft?
 
 Wenn Angebote bestimmte Barrierefreiheitsfunktionen enthalten, sollten diese gut dokumentiert sein, denn viele Nutzer werden ohne ausdrückliche Hinweise diese Funktionen nicht erkennen oder nutzen können.
 

--- a/Prüfschritte/de/12.2.2 Technischer Support.adoc
+++ b/Prüfschritte/de/12.2.2 Technischer Support.adoc
@@ -12,7 +12,7 @@ ifndef::env_embedded[]
 endif::env_embedded[]
 ).
 
-== Warum wir das geprüft?
+== Warum wird das geprüft?
 
 Hinweise zu Barrierefreiheits-Funktionen sind nicht immer verständlich genug. Hinweise zur Hilfsmittel-Kompatibilität können schnell veraltet sein. Es ist wichtig, dass der technische Support auf Kunden-Fragen eingehen und Hilfe bereitstellen kann.
 

--- a/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
+++ b/Prüfschritte/de/5.2 Aktivierung von Barrierefreiheitsfunktionen.adoc
@@ -56,11 +56,11 @@ Bedienelemente für Barrierefreiheits-Funktionen sollen grundsätzlich alle Barr
 
 === 4. Bewertung
 
-==== Erfüllt:
+==== Erfüllt
 
 Die Barrierefreiheits-Funktion ist barrierefrei identifizierbar und aktivierbar.
 
-==== Nicht voll erfüllt:
+==== Nicht voll erfüllt
 
 Bedienelemente der Barrierefreiheitsfunktion oder die Funktion selbst verstoßen gegen Anforderungen der EN.
 

--- a/Prüfschritte/de/5.3 Biometrie.adoc
+++ b/Prüfschritte/de/5.3 Biometrie.adoc
@@ -34,11 +34,11 @@ Zurzeit sind biometrische Aspekte der Steuerung hauptsächlich die Nutzer-Identi
 
 === 4. Bewertung
 
-==== Erfüllt:
+==== Erfüllt
 
 Neben biometrischer Identifizierung oder Steuerung gibt es mindestens eine weitere nicht-biometrische oder biometrische Methode.
 
-==== Nicht erfüllt:
+==== Nicht erfüllt
 
 Nutzeridentifizierung oder Steuerung sind nur über **ein** biometrisches Merkmal möglich, es gibt keine Alternativen dazu.
 

--- a/Prüfschritte/de/5.4 Erhaltung von Barrierefreiheitsinformationen bei Konvertierung.adoc
+++ b/Prüfschritte/de/5.4 Erhaltung von Barrierefreiheitsinformationen bei Konvertierung.adoc
@@ -32,11 +32,11 @@ Informationen, die das Zielformat nicht unterstützt, sollen bei der Prüfung ni
 
 === 4. Bewertung
 
-==== Erfüllt:
+==== Erfüllt
 
 Das Zielformat enthält alle Barrierefreiheits-Informationen des Ausgangsformats, die grundsätzlich unterstützt werden.
 
-==== Nicht voll erfüllt:
+==== Nicht voll erfüllt
 
 Grundsätzlich vom Zielformat unterstützte Barrierefreiheits-Informationen des Ausgangsformats gehen bei der Konvertierung verloren.
 

--- a/Prüfschritte/de/6.2.1.2 Gleichzeitige Sprache und Text.adoc
+++ b/Prüfschritte/de/6.2.1.2 Gleichzeitige Sprache und Text.adoc
@@ -29,7 +29,7 @@ Bei Konferenzen, die gleichzeitig eine herkömmliche Chat-Funktion bieten, solle
 
 == 4. Einordnung des Prüfschritts
 
-=== Einordnung des Prüfschritt nach EN 301 549 V3.1.1
+=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1
 
 6.2.1.2 Concurrent voice and text
 

--- a/Prüfschritte/de/6.2.2.1 Visuell unterscheidbare Anzeige von Textnachrichten.adoc
+++ b/Prüfschritte/de/6.2.2.1 Visuell unterscheidbare Anzeige von Textnachrichten.adoc
@@ -45,7 +45,7 @@ Der Prüfschritt ist anwendbar, wenn die Webangebot Echtzeit Textkommunikation s
 
 Wenn Nachrichten des Senders und des Empfängers nur über die Farbe des Textes unterschieden werden können und der Kontrastunterschied beider Arten von Nachricht unter 3:1 liegt, sind sowohl dieser Prüfschritt als auch Prüfschritt 1.4.1a "Ohne Farbe nutzbar" nicht erfüllt. Andere Anforderungen (etwa das der Text selbst oder auch Rahmen oder andere grafische Elemente zur Unterscheidung kontrastreich genug sind) werden außerdem in den dafür zuständigen Prüfschritten bewertet.
 
-== Quelle
+== Quellen
 
 [.BLOCK_LANG_EN]
 === 6.2.2.1 Visually distinguishable display

--- a/Prüfschritte/de/6.2.2.2 Programmatisch unterscheidbare Anzeige von Textnachrichten.adoc
+++ b/Prüfschritte/de/6.2.2.2 Programmatisch unterscheidbare Anzeige von Textnachrichten.adoc
@@ -10,9 +10,9 @@ Wenn die Web-Anwendung eine Funktion zur Echtzeit Textkommunikation anbietet, so
 
 Wenn Menschen, die Hilfsmittel wie Screenreader einsetzen, die Äußerungen in einer Kommunikation lesen wollen, müssen sie eigene Text-Beiträge von denen anderer unterscheiden können. Darum muss die Sende- und Empfangsrichtung programmatisch ermittelbar sein. (Darüber hinaus ist es auch sinnvoll, programmatisch zwischen empfangenen Texten verschiedener Teilnehmer:innen unterscheiden zu können.)
 
-== 1. Wie wird geprüft?
+== Wie wird geprüft?
 
-=== Anwendbarkeit des Prüfschritts
+=== 1. Anwendbarkeit des Prüfschritts
 
 Der Prüfschritt ist anwendbar, wenn die Web-Anwendung Echtzeit Textkommunikation senden und empfangen kann.
 
@@ -35,11 +35,11 @@ Die Anforderung verlangt streng genommen nur die Unterscheidung der Senderichtun
 
 === 4. Bewertung
 
-==== Erfüllt: 
+==== Erfüllt
 
 Die Eingaben des Nutzers selbst und die emfangenen Echtzeit-Texteingaben anderer Nutzer sind programmatisch unterscheidbar, z.B. über einen Präfix.
 
-==== Eher erfüllt:
+==== Eher erfüllt
 
 Die Eingaben des Nutzers selbst snd von emfangenen Echtzeit-Texteingaben anderer Nutzer sind programmatisch unterscheidbar, die anderen Nutzer sind aber nicht unterscheidbar.
 
@@ -47,9 +47,9 @@ Die Eingaben des Nutzers selbst snd von emfangenen Echtzeit-Texteingaben anderer
 
 Es gibt beim Lesen der Echtzeit-Texteingaben einer Kommunikation keine Möglichkeit, programmatisch zwischen eigenen und fremden Eingaben zu unterscheiden.
 
-== Einordnung des Prüfaschritts 
+== Einordnung des Prüfschritts
 
-=== Einordnung des Prüfschritts nach EN 301 549 V.3.1.1
+=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1
 
 * 6.2.2 "Display of RTT"
 * 6.2.2.2 Programmatically determinable send and receive direction

--- a/Prüfschritte/de/6.2.3 Interopabilität von Echtzeit-Textkommunikation.adoc
+++ b/Prüfschritte/de/6.2.3 Interopabilität von Echtzeit-Textkommunikation.adoc
@@ -44,7 +44,7 @@ und fehlerhaft übertragenen Zeichen.
   
 == Einordnung des Prüfschritts
 
-=== Einordnung des Prüfschriftts nach EN 301 549 V3.1.1
+=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1
 
 * 6.2.3 Interoperability
 

--- a/Prüfschritte/de/6.2.4 Reaktionsgeschwindigkeit der Echtzeit-Textkommunikation.adoc
+++ b/Prüfschritte/de/6.2.4 Reaktionsgeschwindigkeit der Echtzeit-Textkommunikation.adoc
@@ -10,7 +10,7 @@ Wenn das Webangebot Echtzeit-Textkommunikation unterstützt und entsprechende Nu
 
 (folgt)
 
-== Wie wird das geprüft?
+== Wie wird geprüft?
 
 === 1. Anwendbarkeit des Prüfschritts
 
@@ -33,9 +33,9 @@ Es sollte eine maximale Verzögerung von 300 Millisekunden für das Abschicken d
 
 Für Hinweise, wie dies zuverlässig in der Praxis gemessen werden kann, können Sie auf GitHub https://github.com/BIK-BITV/BIK-Web-Test/issues[ein Issue eröffnen].
 
-== Einordung des Prüfschritts
+== Einordnung des Prüfschritts
 
-=== Einordnunng des Prüfschritts nach EN 301 549 V3.1.1
+=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1
 
 6.2.4 RTT responsiveness
 

--- a/Prüfschritte/de/7.1.1 Wiedergabe von Untertiteln.adoc
+++ b/Prüfschritte/de/7.1.1 Wiedergabe von Untertiteln.adoc
@@ -43,11 +43,11 @@ Damit closed captions (dynamisch zuschaltbare Untertitel) von den Nutzenden wahr
 
 === 4. Bewertung
 
-==== Erfüllt: 
+==== Erfüllt
 
 Sind Videos mit synchroner Bild- und Tonspur vorhanden, werden Untertitel als fester Bestandteil des Videos angezeigt (open captions) oder können über ein Bedienelement des Videoplayers ein- und ausgeblendet werden (closed captions).
 
-==== Nicht voll erfüllt: 
+==== Nicht voll erfüllt
 
 Es wird eine Untertitel-Datei angeboten, der Player bietet jedoch keine Möglichkeit, diese anzuzeigen.
 

--- a/Prüfschritte/de/7.1.3 Erhaltung von Untertiteln.adoc
+++ b/Prüfschritte/de/7.1.3 Erhaltung von Untertiteln.adoc
@@ -65,7 +65,7 @@ ifndef::env_embedded[]
 endif::env_embedded[]
 geht es hingegen um Videos, die auf der Webseite bereits vorhanden sind.
 
-=== Einordnung des Prüfschritts nach EN 301 549 v.3.1.1
+=== Einordnung des Prüfschritts nach EN 301 549 V3.1.1
 
 7.1.3  Preservation of captioning.
 

--- a/Prüfschritte/de/9.1.1.1b Alternativtexte für Grafiken und Objekte.adoc
+++ b/Prüfschritte/de/9.1.1.1b Alternativtexte für Grafiken und Objekte.adoc
@@ -351,7 +351,7 @@ endif::env_embedded[]
   content so that it can be changed into other forms people need, such as
   large print, braille, speech, symbols or simpler language]
 
-==== Success Criterion
+==== Success criterion
 
 * http://www.w3.org/TR/WCAG21/#x1-1-1-non-text-content[
   1.1.1 Non-text Content] (Level A)

--- a/Prüfschritte/de/9.1.1.1c Leere alt-Attribute für Layoutgrafiken.adoc
+++ b/Prüfschritte/de/9.1.1.1c Leere alt-Attribute für Layoutgrafiken.adoc
@@ -126,7 +126,7 @@ Die anderen Teilbilder sollten mit leeren ``alt``-Attributen versehen sein.
   content so that it can be changed into other forms people need, such as large
   print, braille, speech, symbols or simpler language]
 
-==== Success Criterion
+==== Success criterion
 
 * http://www.w3.org/TR/WCAG21/#x1-1-1-non-text-content[
   1.1.1 Non-text Content] (Level A)

--- a/Prüfschritte/de/9.1.1.1d Alternativen für CAPTCHAs.adoc
+++ b/Prüfschritte/de/9.1.1.1d Alternativen für CAPTCHAs.adoc
@@ -93,7 +93,7 @@ endif::env_embedded[] geprüft.
   content so that it can be changed into other forms people need, such as large
   print, braille, speech, symbols or simpler language]
 
-==== Success Criterion
+==== Success criterion
 
 * http://www.w3.org/TR/WCAG21/#x1-1-1-non-text-content[
   1.1.1 Non-text Content] (Level A)

--- a/Prüfschritte/de/9.1.3.1g Kein Strukturmarkup für Layouttabellen.adoc
+++ b/Prüfschritte/de/9.1.3.1g Kein Strukturmarkup für Layouttabellen.adoc
@@ -68,7 +68,7 @@ sind, sollten semantische Elemente nicht benutzt werden.
 * https://www.w3.org/WAI/WCAG21/Techniques/html/H73.html[
   H73 Using the `summary` attribute of the `table` element]
 
-===== Failure
+===== Failures
 
 * https://www.w3.org/WAI/WCAG21/Techniques/failures/F46.html[
   F46 Failure of Success Criterion 1.3.1 due to using `th` elements, `caption`

--- a/Prüfschritte/de/9.1.3.2 Sinnvolle Reihenfolge.adoc
+++ b/Prüfschritte/de/9.1.3.2 Sinnvolle Reihenfolge.adoc
@@ -96,7 +96,7 @@ Rolle.
 
 == Einordnung des Prüfschritts
 
-=== Abgerenzung zu anderen Prüfschritten
+=== Abgrenzung zu anderen Prüfschritten
 
 * _Custom controls_, die etwa Benutzerschnittstellen aus positionierten `div`s
   mit Hintergrundbildern erzeugen, werden bereits in einer Reihe von
@@ -128,7 +128,7 @@ endif::env_embedded[]
   Guideline 1.3 Adaptable: Create content that can be presented in different
   ways (for example simpler layout) without losing information or structure.]
 
-==== Success criterio
+==== Success criterion
 
 * https://www.w3.org/WAI/WCAG21/quickref/?showtechniques=131#meaningful-sequence[
   1.3.2 Meaningful Sequence] (Level A)

--- a/Prüfschritte/de/9.2.4.2 Sinnvolle Dokumenttitel.adoc
+++ b/Prüfschritte/de/9.2.4.2 Sinnvolle Dokumenttitel.adoc
@@ -37,7 +37,7 @@ Falls Seiten Frames haben:
   Haben die Frame-Seiten sinnvolle Titel, die Zweck oder Inhalt des Frames
   kennzeichnen?
 
-=== 3. Hinweis
+=== 3. Hinweise
 
 Der Dokumenttitel muss nicht den Pfad von der Startseite zur aktuellen Seite
 wiedergeben.
@@ -95,7 +95,7 @@ Bookmarks-Liste.
 * https://www.w3.org/WAI/WCAG21/Techniques/html/H86.html[
   H86: Providing text alternatives for ASCII art, emoticons, and leetspeak]
 
-==== Failure
+==== Failures
 
 * https://www.w3.org/WAI/WCAG21/Techniques/failures/F25.html[
   F25: Failure of Success Criterion 2.4.2 due to the title of a Web page not

--- a/Prüfschritte/de/9.3.1.2 Anderssprachige Wörter und Abschnitte ausgezeichnet.adoc
+++ b/Prüfschritte/de/9.3.1.2 Anderssprachige Wörter und Abschnitte ausgezeichnet.adoc
@@ -29,7 +29,7 @@ oder andere größere Abschnitte in einer anderen Sprache enthält.
   Lang bookmarklet] aufrufen.
 . Prüfen, ob anderssprachige Wörter und Abschnitte richtig ausgezeichnet sind. Ausnahmen gelten für Eigennamen, Fachbegriffe und unklare Sprache (siehe <<3.Hinweise>>).
 
-=== 3.Hinweise
+=== 3. Hinweise
 
 * Keinen praktischen Nutzen hat die Auszeichnung von Wörtern, die ohne
   Auszeichnung üblicherweise nicht anders ausgesprochen werden.

--- a/Prüfschritte/de/9.3.3.4 Fehlervermeidung wird unterstützt.adoc
+++ b/Prüfschritte/de/9.3.3.4 Fehlervermeidung wird unterstützt.adoc
@@ -98,7 +98,7 @@ Erfolgreiche Eingaben sollten nach dem Abschicken bestätigt werden.
 
 ==== Techniques
 
-===== General techniques
+===== General Techniques
 
 * https://www.w3.org/WAI/WCAG21/Techniques/general/G98.html[
   G98: Providing the ability for the user to review and correct answers before

--- a/Prüfschritte/de/9.4.1.1 Korrekte Syntax.adoc
+++ b/Prüfschritte/de/9.4.1.1 Korrekte Syntax.adoc
@@ -20,7 +20,7 @@ mit der Seite.
 
 == Wie wird geprüft?
 
-=== 1. Anwendbarkeit des Prüfschritts:
+=== 1. Anwendbarkeit des Prüfschritts
 
 Der Prüfschritt ist immer anwendbar.
 


### PR DESCRIPTION
Korrektur kleinerer wiederkehrender Tippfehler in Überschriften: z.B. " Prüfschrtts", "Prüfschriftts" ...

Vereinheitlichung der Schreibweise der Überschriften.
Grundlage der Vereinheitlichung ist die Auswertung der bisher am häufigsten vorwendete Schreibweise.
z.B. "Erfüllt:" -> "Erfüllt", "v3.1.1" und V 3.1.1" -> "V3.1.1"