### PR TITLE
12.2.2 Technischer Support: Gliederung der "Anwendbarkeit" in zwei Punkte (Verbesserung der Verständlichkeit).adoc

### DIFF
--- a/Prüfschritte/de/12.2.2 Technischer Support.adoc
+++ b/Prüfschritte/de/12.2.2 Technischer Support.adoc
@@ -20,11 +20,13 @@ Hinweise zu Barrierefreiheits-Funktionen sind nicht immer verständlich genug. H
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist anwendbar, wenn das Webangebot (meist eine Web-Anwendung) einen technischen Support anbietet und wenn in der Dokumentation Informationen zu Barrierefreiheits-Funktionen oder zur Hilfsmittel-Kompatibilität bereitgestellt werden.
+Der Prüfschritt ist anwendbar, wenn das Webangebot (meist eine Web-Anwendung)
+
+* technische Dokumentation für das Webangebot anbietet, und
+* Barrierefreiheits-Funktionen und Hinweise auf Hilfsmittel-Kompatibitität in dieser Dokumentation einschließt.
 
 === 2. Prüfung
 
-. Prüfen, ob das Webangebot einen Kontakt zu einem technischen Support anbietet.
 . Den technischen Support kontaktieren und stichprobenartig Fragen zu den in der Dokumentation genannten Barrierefreiheits-Funktionen oder zur Hilfsmittel-Kompatibilität stellen.
 . Ist der technische Support in der Lage, mündlich oder schriftlich zusätzliche Informationen und Hilfestellungen zu geben?
 

--- a/Prüfschritte/de/12.2.2 Technischer Support.adoc
+++ b/Prüfschritte/de/12.2.2 Technischer Support.adoc
@@ -23,7 +23,7 @@ Hinweise zu Barrierefreiheits-Funktionen sind nicht immer verständlich genug. H
 Der Prüfschritt ist anwendbar, wenn das Webangebot (meist eine Web-Anwendung)
 
 * technische Dokumentation für das Webangebot anbietet, und
-* wenn in dieser Dokumentation Barrierefreiheits-Funktionen und Hinweise auf Hilfsmittel-Kompatibitität vorhanden sind.
+* Barrierefreiheits-Funktionen und Hinweise auf Hilfsmittel-Kompatibitität in dieser Dokumentation eingeschlossen sind.
 
 === 2. Prüfung
 

--- a/Prüfschritte/de/12.2.2 Technischer Support.adoc
+++ b/Prüfschritte/de/12.2.2 Technischer Support.adoc
@@ -23,7 +23,7 @@ Hinweise zu Barrierefreiheits-Funktionen sind nicht immer verständlich genug. H
 Der Prüfschritt ist anwendbar, wenn das Webangebot (meist eine Web-Anwendung)
 
 * technische Dokumentation für das Webangebot anbietet, und
-* Barrierefreiheits-Funktionen und Hinweise auf Hilfsmittel-Kompatibitität in dieser Dokumentation einschließt.
+* wenn in dieser Dokumentation Barrierefreiheits-Funktionen und Hinweise auf Hilfsmittel-Kompatibitität vorhanden sind.
 
 === 2. Prüfung
 


### PR DESCRIPTION
- Der Erste Punkt in Prüfung (". Prüfen, ob das Webangebot einen Kontakt zu einem technischen Support anbietet.") kann entfallen, da schon in Anwendbarkeit abgedeckt.
- Ich habe Maja Benkes Vorschlag, die Anwendbarkeit in zwei Punkte zu gliedern, aufgegriffen, aber etwas nährer dran am Text der EN

Closes #191 