### PR TITLE
Update 11.7 Benutzerdefinierte Einstellungen.adoc

### DIFF
--- a/Prüfschritte/de/11.7 Benutzerdefinierte Einstellungen.adoc
+++ b/Prüfschritte/de/11.7 Benutzerdefinierte Einstellungen.adoc
@@ -8,7 +8,7 @@ Die Seite soll benutzerdefinierte Browsereinstellungen berücksichtigen.
 Im Einzelnen können dies folgende Punkte sein:
 
 * Maßeinheiten
-* Farben (z. B. Darkmode)
+* Farben
 * Kontraste
 * Schriftarten
 * Schriftgrößen


### PR DESCRIPTION
Verweis auf dark mode entfernt.

Siehe Diskussion in  #207 
Für Webangebote git der Browser als die Systemumgebung, deren Einstellungen übernommen werden sollen.
Dark mode ist eine Betriebssystemeinstellung, die hier deshalb missverständlich wäre.

Closes #207 