### PR TITLE
9.2.4.4 Grundlegende Überarbeitung "Aussagekräftige Linktexte"

### DIFF
--- a/Prüfschritte/de/9.2.4.4 Aussagekräftige Linktexte.adoc
+++ b/Prüfschritte/de/9.2.4.4 Aussagekräftige Linktexte.adoc
@@ -48,7 +48,7 @@ Der Prüfschritt ist anwendbar, wenn die Seite Links enthält.
 . Seite im Browser aufrufen.
 . Prüfen, ob visuell, etwa über zusätzliche Icons oder in Custom-Tooltips, Auskunft über das Dateiformat gegeben wird. 
 . Prüfen, ob visuelle Information zum Dateiformat auch programmatisch bereitgestellt wird (etwa über versteckten Linktext, Alternativtext, das `title`-Attribut oder geeignete ARIA-Attribute).
-. Falls über Link- und title-Text keine Auskunft über das Dateiformat gegeben wird, ist das Dateiformat des Link möglicherweise für alle Nutzenden unklar. Dies ist nicht als Mangel im Sinne dieses Prüfschritts zu bewerten (sollte jedoch ggf. als allgemeines Usability-Problem angemerkt werden).
+. Falls über Link- und title-Text keine Auskunft über das Dateiformat gegeben wird, ist das Dateiformat des Links möglicherweise für alle Nutzenden unklar. Dies ist nicht als Mangel im Sinne dieses Prüfschritts zu bewerten (sollte jedoch ggf. als allgemeines Usability-Problem angemerkt werden).
 
 === 3. Hinweise
 

--- a/Prüfschritte/de/9.2.4.4 Aussagekräftige Linktexte.adoc
+++ b/Prüfschritte/de/9.2.4.4 Aussagekräftige Linktexte.adoc
@@ -31,26 +31,17 @@ Der Prüfschritt ist anwendbar, wenn die Seite Links enthält.
 ==== 2.1 Prüfung von Linktexten
 
 . Seite im Firefox aufrufen.
-. Prüfen, ob die Linktexte aussagekräftig sind, das heißt, im Linktext oder
-  im Kontext eine Auskunft über Ziel oder Zweck des Links geben.
-. Für Links, deren sichtbarer Linktext allein nicht aussagekräftig ist (z. B.
-  "mehr" oder "weiterlesen"), prüfen, ob der Linktext durch eine der
-  folgenden Möglichkeiten im Kontext sinnvoll ergänzt wird:
+. Prüfen, ob die Linktexte aussagekräftig sind, das heißt, im Linktext oder im Kontext eine Auskunft über Ziel oder Zweck des Links geben.
+. Für Links, deren sichtbarer Linktext allein nicht aussagekräftig ist (z. B. "mehr" oder "weiterlesen"), prüfen, ob der Linktext durch eine dee folgenden Möglichkeiten im Kontext sinnvoll ergänzt wird:
 +
-* durch einen verständlichen Link am Seitenbeginn, der Linktexte auf der
-  Seite erweitert
-* durch zusätzlichen, über CSS versteckten Linktext (hierfür in der Web
-  Developer Toolbar die Option _CSS > Disable All Styles_ wählen und die
-  betroffenen Links erneut prüfen)
-* durch den Alternativtext einer mit im selben ``a``-Element verlinkten Grafik
-(hierfür die Option _Images > Display Alt Attributes_ wählen)
+* durch einen verständlichen Link am Seitenbeginn, der Linktexte auf der Seite erweitert
+* durch zusätzlichen, über CSS versteckten Linktext (hierfür in der Web Developer Toolbar die Option _CSS > Disable All Styles_ wählen und die betroffenen Links erneut prüfen)
+* durch den Alternativtext einer mit im selben ``a``-Element verlinkten Grafik (hierfür die Option _Images > Display Alt Attributes_ wählen)
 * durch den Text im umschließenden Element (`p`, `li`)
-* bei Links in untergeordneten Listen durch den Text des übergeordneten
-  ``li``-Elements
-* durch den Text der umschließenden Tabellenzelle und der dazugehörigen
-  Überschriftenzellen (``td``, ``th``)
-* durch den Text der vorangehenden Überschrift (``h1`` - ``h6``)
-* Mit Hilfe des `aria-label` oder ``aria-labelledby``-Attributs.
+* bei Links in untergeordneten Listen durch den Text des übergeordneten `li`-Elements
+* durch den Text der umschließenden Tabellenzelle und der dazugehörigen Überschriftenzellen (`td`, `th`)
+* durch den Text der vorangehenden Überschrift (`h1` - `h6`)
+* Mit Hilfe des `aria-label` oder `aria-labelledby`-Attributs (Achtung: `aria-label` überschreibt den Text des Links).
 
 ==== 2.2 Prüfung von Links auf andere Dateiformate
 

--- a/Prüfschritte/de/9.2.4.4 Aussagekräftige Linktexte.adoc
+++ b/Prüfschritte/de/9.2.4.4 Aussagekräftige Linktexte.adoc
@@ -32,16 +32,16 @@ Der Prüfschritt ist anwendbar, wenn die Seite Links enthält.
 
 . Seite im Firefox aufrufen.
 . Prüfen, ob die Linktexte aussagekräftig sind, das heißt, im Linktext oder im Kontext eine Auskunft über Ziel oder Zweck des Links geben.
-. Für Links, deren sichtbarer Linktext allein nicht aussagekräftig ist (z. B. "mehr" oder "weiterlesen"), prüfen, ob der Linktext durch eine dee folgenden Möglichkeiten im Kontext sinnvoll ergänzt wird:
+. Für Links, deren sichtbarer Linktext allein nicht aussagekräftig ist (z. B. "mehr" oder "weiterlesen"), prüfen, ob der Linktext durch eine der folgenden Möglichkeiten im Kontext sinnvoll ergänzt wird:
 +
-* durch einen verständlichen Link am Seitenbeginn, der Linktexte auf der Seite erweitert
-* durch zusätzlichen, über CSS versteckten Linktext (hierfür in der Web Developer Toolbar die Option _CSS > Disable All Styles_ wählen und die betroffenen Links erneut prüfen)
-* durch den Alternativtext einer mit im selben ``a``-Element verlinkten Grafik (hierfür die Option _Images > Display Alt Attributes_ wählen)
-* durch den Text im umschließenden Element (`p`, `li`)
+* durch zusätzlichen, über CSS versteckten Linktext (hierfür ggf. in der Web Developer Toolbar die Option _CSS > Disable All Styles_ wählen und die betroffenen Links erneut prüfen)
+* durch den Alternativtext einer mit im selben `a`-Element verlinkten Grafik (hierfür die Option _Images > Display Alt Attributes_ wählen)
+* durch den Text im umschließenden Element (`p`, `li`). Das `div`-Element wird hier wie `p` behandelt
 * bei Links in untergeordneten Listen durch den Text des übergeordneten `li`-Elements
 * durch den Text der umschließenden Tabellenzelle und der dazugehörigen Überschriftenzellen (`td`, `th`)
 * durch den Text der vorangehenden Überschrift (`h1` - `h6`)
-* Mit Hilfe des `aria-label` oder `aria-labelledby`-Attributs (Achtung: `aria-label` überschreibt den Text des Links).
+* Mit Hilfe des `aria-label` oder `aria-labelledby`-Attributs (Achtung: `aria-label` überschreibt den Text des Links)
+* durch einen verständlichen Link am Seitenbeginn, der Linktexte auf der Seite erweitert.
 
 ==== 2.2 Prüfung von Links auf andere Dateiformate
 

--- a/Prüfschritte/de/9.2.4.4 Aussagekräftige Linktexte.adoc
+++ b/Prüfschritte/de/9.2.4.4 Aussagekräftige Linktexte.adoc
@@ -12,32 +12,13 @@ Dateiformat des Zieldokuments informieren.
 
 == Warum wird das geprüft?
 
-Blinde Nutzer, die von Link zu Link tabben, bekommen die Linktexte vorgelesen
-und können bei aussagekräftigen Linktexten leicht entscheiden, ob sie einem
-Link folgen möchten.
+Blinde Nutzer, die von Link zu Link tabben, bekommen die Linktexte vorgelesen und können bei aussagekräftigen Linktexten leicht entscheiden, ob sie einem Link folgen möchten.
 
-Falls der Linktext selbst nicht aussagekräftig ist, soll der unmittelbare
-Kontext für Screenreader-Nutzer wenigstens leicht ermittelbar sein.
+Falls der Linktext selbst nicht aussagekräftig ist, soll der unmittelbare Kontext für Screenreader-Nutzer wenigstens leicht ermittelbar sein.
 
-Screenreader bieten die Möglichkeit der Auflistung sämtlicher Links der Seite
-und damit einen schnellen Überblick, selbst wenn die Seite ansonsten schlecht
-zugänglich ist.
-Diese Technik funktioniert allerdings nicht, wenn alle Linktexte
-gleich sind und nicht ausreichend Auskunft über das Linkziel geben.
+Screenreader bieten die Möglichkeit der Auflistung sämtlicher Links der Seite und damit einen schnellen Überblick, selbst wenn die Seite ansonsten schlecht zugänglich ist. Diese Technik funktioniert allerdings nicht, wenn alle Linktexte gleich sind und nicht ausreichend Auskunft über das Linkziel geben. 
 
-Für Angebote in anderen Formaten als HTML (zum Beispiel PDF- oder
-Word-Dokumente) benötigt der Benutzer zusätzliche Programme oder Plugins, die
-aber nicht jeder auf seinem Rechner installiert hat.
-Manche Programme arbeiten schlecht mit Screenreadern oder anderen
-Hilfsanwendungen zusammen, manche Dateiformate sind nicht oder nur schlecht
-zugänglich.
-Für viele Benutzer ist es wichtig zu wissen, in welchem Format Informationen
-angeboten werden, bevor sie einen Link aktivieren.
-
-Ein weiterer Grund, weshalb die Vorab-Information über den Typ des Links
-wichtig ist: Der Benutzer weiß dann, was auf ihn zukommt.
-Er ist nicht überrascht oder irritiert, wenn plötzlich Browserfunktionen
-nicht mehr vorhanden sind oder der E-Mail-Client geöffnet wird.
+Bei Links zu Angeboten in anderen Formaten als HTML (zum Beispiel PDF- oder Word-Dokumente) ist es für Nutzende sinnvoll zu wissen, in welchem Format Informationen angeboten werden, bevor sie einen Link aktivieren. Wenn Informationen zum Dateiformat visuell bereitgehalten werden (etwa über ein mittels CSS eingeblendetes PDF- oder Word-Icon) dann soll diese Information auch für blinde Nutzer verfügbar sein.
 
 == Wie wird geprüft?
 
@@ -73,50 +54,27 @@ Der Prüfschritt ist anwendbar, wenn die Seite Links enthält.
 
 ==== 2.2 Prüfung von Links auf andere Dateiformate
 
-. Seite im Firefox aufrufen.
-. In der
-  http://www.bitvtest.de/bitvtest/das_testverfahren_im_detail/werkzeugliste.html[
-  Web Developer Toolbar] die Option _Information > View Link Information_
-  wählen.
-. Links auf nicht-HTML-Angebote in der Linkliste anhand der URL identifizieren
-  (zum Beispiel mailto-Links oder die Dateiendungen .pdf oder .doc)
-. Prüfen, ob im Linktext oder im title-Text Auskunft über das Dateiformat
-  gegeben wird oder das Linkziel über die Format des Linktexts deutlich wird -
-  so etwa bei einer verlinkten E-Mail-Adresse.
-. Falls über Link- und title-Text keine Auskunft über das Dateiformat
-  gegeben wird, den Link auf der Webseite suchen und prüfen, ob mit visuellen
-  Mitteln über das Dateiformat informiert wird (zum Beispiel PDF-Symbol,
-  Überschrift "PDFs zum Herunterladen"...).
+. Seite im Browser aufrufen.
+. Prüfen, ob visuell, etwa über zusätzliche Icons oder in Custom-Tooltips, Auskunft über das Dateiformat gegeben wird. 
+. Prüfen, ob visuelle Information zum Dateiformat auch programmatisch bereitgestellt wird (etwa über versteckten Linktext, Alternativtext, das `title`-Attribut oder geeignete ARIA-Attribute).
+. Falls über Link- und title-Text keine Auskunft über das Dateiformat gegeben wird, ist das Dateiformat des Link möglicherweise für alle Nutzenden unklar. Dies ist nicht als Mangel im Sinne dieses Prüfschritts zu bewerten (sollte jedoch ggf. als allgemeines Usability-Problem angemerkt werden).
 
 === 3. Hinweise
 
-* Bei verlinkten Grafiken ist der Linktext der Wert des `alt`-Attributs des
-  ``img``-Elements
-* Der Linktext kann auch aus dem ``alt``-Text einer oder mehrerer Grafiken und
-  einfachem Text zusammengesetzt sein.
-* Nicht aussagekräftige Links wie "mehr..", "weiter", "etc." im letzten
-  ``li``-Element einer Liste werden nur akzeptiert, wenn die Bedeutung klar
-  aus dem Kontext der Auflistung hervorgeht.
-* Zusätzlicher, per CSS unsichtbar gemachter Linktext darf nicht via
-  `display:none` versteckt werden: er wird sonst von Screenreadern ignoriert.
-* Das ``title``-Attribut eines Links wird in manchen Fällen nicht von
-  Screenreadern ausgewertet.
-  Es ist gemäß Spezifikation für zusätzliche Informationen gedacht.
+* Links, deren Ziel generell für alle Nutzer unklar ist, fallen nicht unter diesen Prüfschritt.
+* Verlinkte URLs und verlinkte E-Mail-Adressen vermitteln über ihr Format den Linkzweck (etwa, dass sie einen Email-Client öffnen oder auf ein externes Webangebot verlinken). URLs sind für alle Nutzer möglicherweise nicht aussagekräftig und werden deshalb hier nicht negativ bewertet.
+* Bei verlinkten Grafiken ist der Linktext der Wert des `alt`-Attributs des ``img``-Elements. Der Linktext kann auch aus dem ``alt``-Text einer oder mehrerer Grafiken und einfachem Text zusammengesetzt sein.
+* Nicht aussagekräftige Links wie "mehr..", "weiter", "etc." im letzten ``li``-Element einer Liste werden akzeptiert, wenn die Bedeutung
+  aus dem programmatisch ermittelbaren Kontext hervorgeht. Dazu gehört der den Link einschließende Absatz oder Listenpunkt oder auch die vorangehende Überschrift. 
+* Wenn zusätzlicher, per CSS unsichtbar gemachter Linktext mit `display:none` versteckt wird, ist er programmatisch nicht ermittelbar und verbessert nicht die Ausagekraft des Links: dieser Text wird von Screenreadern ignoriert.
+* Das ``title``-Attribut eines Links ist potenziell programmatisch ermittelbar, wird aber in manchen Fällen (abhängig von Einstellungen) nicht von Screenreadern ausgewertet.
 
 === 4. Bewertung
 
 ==== Erfüllt
 
-* Alle Links benennen im Linktext oder im direkten Kontext Linkziel oder
-  Linkzweck.
-* Alle Links auf nicht-HTML-Angebote geben Auskunft über das Dateiformat oder
-  lassen klar auf das Verhalten bei Aktivierung schließen (etwa bei
-  verlinkten E-Mail Adressen, die einen E-Mail client öffnen).
-
-==== Nicht voll erfüllt
-
-* Ziel oder Zweck des Links gehen _nur_ aus dem ``title``-Attribut des Links
-  hervor.
+* Alle Links benennen im Linktext oder im programmatisch ermittelbaren Kontext Linkziel oder Linkzweck.
+* Alle Links auf nicht-HTML-Angebote, die visuell über das Dateiformat informieren, stellen diese Information auch programmatisch ermittelbar zur Verfügung.
 
 == Einordnung des Prüfschritts
 


### PR DESCRIPTION
Wichtige Änderungen:

- Links die ggf. **für alle** unklar sind, fallen nicht unter diesen Prüfschritt. Das betrifft auch verlinkte E-Mail Adressen oder URLs
- Negativ bewertet wird fehlende Info zum Dateiformat in Links nur dann, wenn diese Info visuell vorhanden ist, aber nicht programmatisch

Bezugspunkte für die Überarbeitung sind Diskussionen in der Working Group - siehe zum Beispiel die längere Diskussion hier https://github.com/w3c/wcag/issues/1149 sowie mein PR https://github.com/w3c/wcag/pull/1164