### PR TITLE
7.1.1 Wiedergabe von Untertiteln: Konkretisierung - Anwendbar, wenn Untertitel vorhanden sind (statt zuschaltbar)

### DIFF
--- a/Prüfschritte/de/7.1.1 Wiedergabe von Untertiteln.adoc
+++ b/Prüfschritte/de/7.1.1 Wiedergabe von Untertiteln.adoc
@@ -21,7 +21,7 @@ Damit closed captions (dynamisch zuschaltbare Untertitel) von den Nutzenden wahr
 
 === 1. Anwendbarkeit des Prüfschritts
 
-*	Der Prüfschritt ist anwendbar, wenn die  Webseite aufgezeichnete Videos mit synchroner Bild- und Tonspur anbietet und Untertitel zuschaltbar sind. Die Untertitel sind dann in der Regel innerhalb des ``video``-Elements als getrennte ``track``-Datei verfügbar.
+*	Der Prüfschritt ist anwendbar, wenn die  Webseite aufgezeichnete Videos mit synchroner Bild- und Tonspur anbietet und Untertitel vorhanden sind. Zuschaltbare Untertitel sind in der Regel innerhalb des ``video``-Elements als getrennte ``track``-Datei verfügbar.
 *	Aufgezeichnete Videos ohne Tonspur (stumme Videos) brauchen keine Untertitelung, der Prüfschritt ist für sie nicht anwendbar.
 
 === 2. Prüfung


### PR DESCRIPTION
Anwendbarkeit des Prüfschritts aktualisiert / konkretisiert: Anwendbar, wenn Untertitel vorhanden sind (statt zuschaltbar).
Siehe EN-Formulierung: 
> Where ICT displays video with synchronized audio, it shall have a mode of operation to display the **available** captions.