### PR TITLE
7.3 Bedienelemente für Untertitel und Audiodeskription: Anwendbar, nur wenn UT / AD angeboten werden

### DIFF
--- a/Prüfschritte/de/7.3 Bedienelemente für Untertitel und Audiodeskription.adoc
+++ b/Prüfschritte/de/7.3 Bedienelemente für Untertitel und Audiodeskription.adoc
@@ -15,7 +15,7 @@ Videoplayer bieten den Menschen eine Vielzahl von Interaktionsmöglichkeiten. Am
 === 1. Anwendbarkeit des Prüfschritts
 
 Der Prüfschritt ist anwendbar, wenn auf der Webseite ein Videoplayer eingebunden ist, der Video-Inhalte mit zugehörigen Audioinhalten abspielt und wenn Untertitel und / oder 
-Audiodeskription für das Verständnis nötig sind.
+Audiodeskription angeboten werden.
 
 === 2. Prüfung
 


### PR DESCRIPTION
Anwendbarkeit korrigiert: Anwendbar, wenn UT / AD angeboten werden.
Vergleiche 7.1.1 Wiedergabe von Untertiteln und 7.1.2 Synchrone Untertitel: Bei beiden Prüfschritten ist das Vorhandensein von UT Voraussetzung für die Anwenbarkeit. Logisch wäre, dass das auch bei 7.3 gilt.