### PR TITLE
7.1.5 spoken subtitles

### DIFF
--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -8,7 +8,7 @@ Wenn das Webangebot Videos mit zuschaltbaren bzw. programmatisch ermittelbaren f
 
 == Warum wird das geprüft?
 
-Menschen, die die Originalsprache eines Videos nicht verstehen, profitieren von Untertiteln in ihrer Landessprache. Wenn Untertitel in einer anderen Sprache angeboten werden, sollen diese Untertitel auch blinden oder sehbehinderten Menschen zugänglich sein. Sie können beispielsweise als zusätzliche Tonspur oder über eine Text-to-Speech Funktionalität bereitgestellt werden.
+Menschen, die die Originalsprache eines Videos nicht verstehen, profitieren beispielsweise von Untertiteln in ihrer Landessprache. Wenn Untertitel in einer anderen Sprache angeboten werden, sollen diese Untertitel auch blinden oder sehbehinderten Menschen zugänglich sein. Sie können zum Beispiel als zusätzliche Tonspur oder über eine Text-to-Speech Funktionalität bereitgestellt werden.
 
 == Wie wird geprüft?
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -4,7 +4,7 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Wenn das Webangebot Videos mit einem Orginalton enthält, der nicht der Hauptsprache des Webangebots entspricht, sollen zuschaltbaren bzw. programmatisch ermittelbaren Untertitel, die in der Hauptsprache der Seite angeboten werden über eine Sprachausgabe zugänglich sein. Nicht programmatisch ermittelbar sind Untertitel, die "fest eingebrannt", also Teil der Bildinformation, sind.
+Wenn das Webangebot Videos mit einem Orginalton enthält, der nicht der Hauptsprache des Webangebots entspricht, sollen zuschaltbaren bzw. programmatisch ermittelbaren Untertitel, die in der Hauptsprache der Seite angeboten werden als akustische Ausgabe zugänglich sein, z.B. über eine eigene Tonspur, die den Untertiteln entspricht, oder über eine gnerierte Sprachausgabe der Untertitel. Nicht programmatisch ermittelbar sind Untertitel, die "fest eingebrannt", also Teil der Bildinformation, sind.
 
 == Warum wird das geprüft?
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -39,7 +39,7 @@ Hinweise zu diesem Prüfschritt können Sie auf GitHub https://github.com/BIK-BI
 
 ==== Nicht erfüllt:
 
-* Bei Angeboten mit fremdsprachiger Tonspur und Untertiteln in der Hauptsprache gibt es keine Möglichkeit, eine Sprachausgabe dieser Untertitel zu aktivieren.
+* Bei Angeboten mit fremdsprachiger Tonspur und zuschaltbaren Untertiteln in der Hauptsprache, sind die Untertitel nicht als akustische Ausgabe zugänglich. 
 
 == Einordnung des Prüfschritts
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -4,23 +4,29 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Wenn das Webangebot Videos mit zuschaltbaren bzw. programmatisch ermittelbaren fremdsprachigen Untertiteln überträgt, kann eine Sprachausgabe der Untertitel aktiviert werden. Nicht programmatisch ermittelbar sind Untertitel, die "fest eingebrannt", also Teil der Bildinformation, sind.
+Wenn das Webangebot Videos mit einem Orginalton enthält, der nicht der Hauptsprache des Webangebots entspricht, sollen zuschaltbaren bzw. programmatisch ermittelbaren Untertitel, die in der Hauptsprache der Seite angeboten werden über eine Sprachausgabe zugänglich sein. Nicht programmatisch ermittelbar sind Untertitel, die "fest eingebrannt", also Teil der Bildinformation, sind.
 
 == Warum wird das geprüft?
 
-Menschen, die die Originalsprache eines Videos nicht verstehen, profitieren beispielsweise von Untertiteln in ihrer Landessprache. Wenn Untertitel in einer anderen Sprache angeboten werden, sollen diese Untertitel auch blinden oder sehbehinderten Menschen zugänglich sein. Sie können zum Beispiel als zusätzliche Tonspur oder über eine Text-to-Speech Funktionalität bereitgestellt werden.
+Menschen, die fremdsprachigen Originalton eines Videos nicht verstehen, profitieren von Untertiteln in ihrer Landessprache. Wenn Untertitel in der Hauptsprache des Webangebots angeboten werden, sollen diese Untertitel auch blinden oder sehbehinderten Menschen zugänglich sein. Sie können zum Beispiel als zusätzliche Tonspur oder über eine Text-to-Speech Funktionalität bereitgestellt werden.
 
 == Wie wird geprüft?
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist anwendbar, wenn das Webangebot Videos mit zuschaltbaren bzw. programmatisch ermittelbaren Untertiteln in einer anderen Sprache enthält (subtitles). Auf permanent sichtbare Untertitel, die "fest eingebrannt", also Teil der Bildinformation, sind, ist der Prüfschritt nicht anwendbar.
+Der Prüfschritt ist anwendbar:
+
+* wenn der Original-Ton des Videos fremdsprachig ist (d.h. er entspricht nicht der Hauptsprache des Webauftritts) 
+* und Unteritel in der Hauptsprache des Webauftritts bereitgestellt werden.
+
+Steht eine Tonspur in der Sprache des Webauftritts zur Verfügung, ist der Prüfschritt nicht anwendbar.
 
 === 2. Prüfung
 
 . Webangebot öffnen.
-. Prüfen ob neben der Originalsprache Unteritel in anderen Sprachen angeboten werden.
-. Falls es sich um zuschaltbare bzw. programmatisch ermittelbare fremdsprachige Untertitel handelt: Prüfen, ob sich eine Sprachausgabe der Untertitel aktivieren lässt.
+. Prüfen, ob der Originalton des Videos in der Hauptsprache des Webangebots ist.
+. Prüfen ob neben der Originalsprache Untertitel in der Hauptsprache des Webangebots angeboten werden.
+. Falls es sich dabei um zuschaltbare bzw. programmatisch ermittelbare Untertitel handelt: Prüfen, ob sich eine Sprachausgabe der Untertitel aktivieren lässt.
 
 === 3. Hinweise
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -17,9 +17,8 @@ Menschen, die fremdsprachigen Originalton eines Videos nicht verstehen, profitie
 Der Prüfschritt ist anwendbar:
 
 * wenn der Original-Ton des Videos fremdsprachig ist (d.h. er entspricht nicht der Hauptsprache des Webauftritts) 
-* und Unteritel in der Hauptsprache des Webauftritts bereitgestellt werden.
-
-Steht eine Tonspur in der Sprache des Webauftritts zur Verfügung, ist der Prüfschritt nicht anwendbar.
+* und Untertitel in der Hauptsprache des Webauftritts bereitgestellt werden
+* und wenn es keine Version des Videos mit einer Tonspur in der Hauptsprache des Webauftritts gibt.
 
 === 2. Prüfung
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -23,8 +23,8 @@ Der Prüfschritt ist anwendbar:
 === 2. Prüfung
 
 . Webangebot öffnen.
-. Prüfen, ob der Originalton des Videos in der Hauptsprache des Webangebots ist.
-. Prüfen ob neben der Originalsprache Untertitel in der Hauptsprache des Webangebots angeboten werden.
+. Prüfen, ob der Originalton des Videos von der Hauptsprache des Webangebots abweicht.
+. Prüfen, ob für Videos mit fremdsprachiger Tonspur Untertitel in der Hauptsprache des Webangebots angeboten werden.
 . Falls es sich dabei um zuschaltbare bzw. programmatisch ermittelbare Untertitel handelt: Prüfen, ob sich eine Sprachausgabe der Untertitel aktivieren lässt.
 
 === 3. Hinweise

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -8,7 +8,7 @@ Wenn das Webangebot Videos mit einem Orginalton enthält, der nicht der Hauptspr
 
 == Warum wird das geprüft?
 
-Menschen, die fremdsprachigen Originalton eines Videos nicht verstehen, profitieren von Untertiteln in ihrer Landessprache. Wenn Untertitel in der Hauptsprache des Webangebots angeboten werden, sollen diese Untertitel auch blinden oder seheingeschränkten Menschen zugänglich sein. Sie können zum Beispiel als zusätzliche Tonspur oder über eine Text-to-Speech Funktionalität bereitgestellt werden.
+Für Menschen, die den fremdsprachigen Originalton eines Videos nicht verstehen, ist eine Übersetzung in Untertiteln in der eigenen Sprache wichtig. Diese Untertitel sollen auch für blinde oder seheingeschränkte Menschen als akustische Ausgabe zugänglich sein.
 
 == Wie wird geprüft?
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -8,7 +8,7 @@ Wenn das Webangebot Videos mit einem Orginalton enthält, der nicht der Hauptspr
 
 == Warum wird das geprüft?
 
-Menschen, die fremdsprachigen Originalton eines Videos nicht verstehen, profitieren von Untertiteln in ihrer Landessprache. Wenn Untertitel in der Hauptsprache des Webangebots angeboten werden, sollen diese Untertitel auch blinden oder sehbehinderten Menschen zugänglich sein. Sie können zum Beispiel als zusätzliche Tonspur oder über eine Text-to-Speech Funktionalität bereitgestellt werden.
+Menschen, die fremdsprachigen Originalton eines Videos nicht verstehen, profitieren von Untertiteln in ihrer Landessprache. Wenn Untertitel in der Hauptsprache des Webangebots angeboten werden, sollen diese Untertitel auch blinden oder seheingeschränkten Menschen zugänglich sein. Sie können zum Beispiel als zusätzliche Tonspur oder über eine Text-to-Speech Funktionalität bereitgestellt werden.
 
 == Wie wird geprüft?
 
@@ -29,7 +29,9 @@ Der Prüfschritt ist anwendbar:
 
 === 3. Hinweise
 
-Gängige Video-Player verfügen derzeit meist nicht über die Möglichkeit einer einschaltbaren Sprachausgabe der Untertitel. 
+* Gängige Video-Player verfügen derzeit meist nicht über die Möglichkeit einer einschaltbaren Sprachausgabe der Untertitel.
+* Die Anforderung 7.1.5 Gesprochene Untertitel soll blinden und seheingeschränkten Nutzenden Untertitel in der Hauptsprache der Seite zugänglich machen, sofern der Original-Ton des Videos dieser nicht entspricht. 
+Ist der Original-Ton des Videos bereits in der Hauptsprache, so gelten Untertitel in anderen Sprachen als zusätzliche Informationen und sind daher nicht von der Anforderung betroffen.
 
 Hinweise zu diesem Prüfschritt können Sie auf GitHub https://github.com/BIK-BITV/BIK-Web-Test/issues[in einem Issue anlegen].
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -25,7 +25,7 @@ Der Prüfschritt ist anwendbar:
 . Webangebot öffnen.
 . Prüfen, ob der Originalton des Videos von der Hauptsprache des Webangebots abweicht.
 . Prüfen, ob für Videos mit fremdsprachiger Tonspur Untertitel in der Hauptsprache des Webangebots angeboten werden.
-. Falls es sich dabei um zuschaltbare bzw. programmatisch ermittelbare Untertitel handelt: Prüfen, ob sich eine Sprachausgabe der Untertitel aktivieren lässt.
+. Prüfen, ob sich eine alternative Tonspur in der Hauptsprache des Angebots oder eine generierte Sprachausgabe der Untertitel aktivieren lässt.
 
 === 3. Hinweise
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -39,7 +39,7 @@ Hinweise zu diesem Prüfschritt können Sie auf GitHub https://github.com/BIK-BI
 
 ==== Nicht erfüllt:
 
-* Bei Angeboten mit fremdsprachiger Tonspur und zuschaltbaren Untertiteln in der Hauptsprache, sind die Untertitel nicht als akustische Ausgabe zugänglich. 
+* Bei Videos mit fremdsprachiger Tonspur und zuschaltbaren Untertiteln in der Hauptsprache, sind die Untertitel nicht als akustische Ausgabe zugänglich. 
 
 == Einordnung des Prüfschritts
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -30,8 +30,7 @@ Der Prüfschritt ist anwendbar:
 === 3. Hinweise
 
 * Gängige Video-Player verfügen derzeit meist nicht über die Möglichkeit einer einschaltbaren Sprachausgabe der Untertitel.
-* Die Anforderung 7.1.5 Gesprochene Untertitel soll blinden und seheingeschränkten Nutzenden Untertitel in der Hauptsprache der Seite zugänglich machen, sofern der Original-Ton des Videos dieser nicht entspricht. 
-Ist der Original-Ton des Videos bereits in der Hauptsprache, so gelten Untertitel in anderen Sprachen als zusätzliche Informationen und sind daher nicht von der Anforderung betroffen.
+* Für Menschen, die den fremdsprachigen Originalton eines Videos nicht verstehen, sollen Untertitel in der Hauptsprache der Webseite für blinde oder seheingeschränkte Menschen als akustische Ausgabe zugänglich sein. Ist der Original-Ton des Videos bereits in der Hauptsprache, so gelten Untertitel in anderen Sprachen als zusätzliche Informationen und sind daher nicht von der Anforderung betroffen.
 
 Hinweise zu diesem Prüfschritt können Sie auf GitHub https://github.com/BIK-BITV/BIK-Web-Test/issues[in einem Issue anlegen].
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -1,4 +1,4 @@
-= Prüfschritt 7.1.5 Gesprochene fremdsprachige Untertitel
+= Prüfschritt 7.1.5 Gesprochene Untertitel
 include::include/author.adoc[]
 include::include/attributes.adoc[]
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -30,7 +30,7 @@ Der Prüfschritt ist anwendbar:
 === 3. Hinweise
 
 * Gängige Video-Player verfügen derzeit meist nicht über die Möglichkeit einer einschaltbaren Sprachausgabe der Untertitel.
-* Für Menschen, die den fremdsprachigen Originalton eines Videos nicht verstehen, sollen Untertitel in der Hauptsprache der Webseite für blinde oder seheingeschränkte Menschen als akustische Ausgabe zugänglich sein. Ist der Original-Ton des Videos bereits in der Hauptsprache, so gelten Untertitel in anderen Sprachen als zusätzliche Informationen und sind daher nicht von der Anforderung betroffen.
+* Für blinde oder sehbehinderte Menschen, die den fremdsprachigen Originalton eines Videos nicht verstehen, sollen Untertitel in der Hauptsprache der Webseite als akustische Ausgabe zugänglich sein. Ist der Original-Ton des Videos bereits in der Hauptsprache, so gelten Untertitel in anderen Sprachen als zusätzliche Informationen und sind daher nicht von der Anforderung betroffen.
 
 Hinweise zu diesem Prüfschritt können Sie auf GitHub https://github.com/BIK-BITV/BIK-Web-Test/issues[in einem Issue anlegen].
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -38,7 +38,7 @@ Hinweise zu diesem Prüfschritt können Sie auf GitHub https://github.com/BIK-BI
 
 ==== Nicht erfüllt:
 
-* Bei zuschaltbaren, programmatisch ermittelbaren fremdsprachigen Untertiteln gibt es keine Möglichkeit, eine Sprachausgabe der Untertitel zu aktivieren.
+* Bei Angeboten mit fremdsprachiger Tonspur und Untertiteln in der Hauptsprache gibt es keine Möglichkeit, eine Sprachausgabe dieser Untertitel zu aktivieren.
 
 == Einordnung des Prüfschritts
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -1,26 +1,26 @@
-= Prüfschritt 7.1.5 Gesprochene Untertitel
+= Prüfschritt 7.1.5 Gesprochene fremdsprachige Untertitel
 include::include/author.adoc[]
 include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Wenn das Webangebot Videos mit zuschaltbaren bzw. programmatisch ermittelbaren Untertiteln überträgt, kann eine Sprachausgabe der Untertitel aktiviert werden. Nicht programmatisch ermittelbar sind Untertitel, die "fest eingebrannt", also Teil der Bildinformation, sind.
+Wenn das Webangebot Videos mit zuschaltbaren bzw. programmatisch ermittelbaren fremdsprachigen Untertiteln überträgt, kann eine Sprachausgabe der Untertitel aktiviert werden. Nicht programmatisch ermittelbar sind Untertitel, die "fest eingebrannt", also Teil der Bildinformation, sind.
 
 == Warum wird das geprüft?
 
-Wenn die Tonqualität eines Videos schlecht ist oder der Ton in einer anderen Sprache, ist es für Untertitel-Nutzende hilfreich, eine Sprachausgabe der Untertitel anzuschalten. Es ist dabei hilfreich, wenn sich die Lautstärke der Sprachausgabe unabhängig von der Lautstärke der Video-Tonspur steuern lässt.
+Menschen, die die Originalsprache eines Videos nicht verstehen, profitieren von Untertiteln in ihrer Landessprache. Wenn Untertitel in einer anderen Sprache angeboten werden, sollen diese Untertitel auch blinden oder sehbehinderten Menschen zugänglich sein. Sie können beispielsweise als zusätzliche Tonspur oder über eine Text-to-Speech Funktionalität bereitgestellt werden.
 
 == Wie wird geprüft?
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist anwendbar, wenn das Webangebot Videos mit zuschaltbaren bzw. programmatisch ermittelbaren Untertiteln enthält (closed captions). Auf permanent sichtbare Untertitel, die "fest eingebrannt", also Teil der Bildinformation, sind, ist der Prüfschritt nicht anwendbar.
+Der Prüfschritt ist anwendbar, wenn das Webangebot Videos mit zuschaltbaren bzw. programmatisch ermittelbaren Untertiteln in einer anderen Sprache enthält (subtitles). Auf permanent sichtbare Untertitel, die "fest eingebrannt", also Teil der Bildinformation, sind, ist der Prüfschritt nicht anwendbar.
 
 === 2. Prüfung
 
 . Webangebot öffnen.
-. Video mit Untertitelung abspielen.
-. Falls es sich um zuschaltbare bzw. programmatisch ermittelbare Untertitel handelt: Prüfen, ob sich eine Sprachausgabe der Untertitel aktivieren lässt.
+. Prüfen ob neben der Originalsprache Unteritel in anderen Sprachen angeboten werden.
+. Falls es sich um zuschaltbare bzw. programmatisch ermittelbare fremdsprachige Untertitel handelt: Prüfen, ob sich eine Sprachausgabe der Untertitel aktivieren lässt.
 
 === 3. Hinweise
 
@@ -32,7 +32,7 @@ Hinweise zu diesem Prüfschritt können Sie auf GitHub https://github.com/BIK-BI
 
 ==== Nicht erfüllt:
 
-* Bei zuschaltbaren, programmatisch ermittelbaren Untertiteln (closed captions) gibt es keine Möglichkeit, eine Sprachausgabe der Untertitel zu aktivieren.
+* Bei zuschaltbaren, programmatisch ermittelbaren fremdsprachigen Untertiteln gibt es keine Möglichkeit, eine Sprachausgabe der Untertitel zu aktivieren.
 
 == Einordnung des Prüfschritts
 


### PR DESCRIPTION
- Prüfschrittname geändert
- Anwendbar, wenn fremdsprachige Untertitel vorhanden sind.
- Warum wird das geprüft: Angepasst.
- FRAGE: Soll der Satz bei "Warum wird das geprüft "Sie können zum Beispiel als zusätzliche Tonspur oder über eine Text-to-Speech Funktionalität bereitgestellt werden." besser raus? Keinen Hinweis zur Umsetzung? Gibt es eine technisch bessere Formulierung?