### PR TITLE
9.1.4.1 ohne farben nutzbar update

### DIFF
--- a/Prüfschritte/de/9.1.4.1 Ohne Farben nutzbar.adoc
+++ b/Prüfschritte/de/9.1.4.1 Ohne Farben nutzbar.adoc
@@ -99,39 +99,15 @@ geprüft.
 
 ==== Abgrenzung zur Prüfung des Markups
 
-In diesem Prüfschritt wird die Auszeichnung von Elementen durch Markup nicht
-beachtet.
-Es geht also um die mehrgleisige Vermittlung von Informationen _auf
-dem Bildschirm_Bei den Prüfkriterien zur richtigen Auszeichnung geht es
-dagegen darum, dass Informationen _unabhängig_ von der Darstellung auf dem
-Bildschirm verfügbar sind oder dass der Benutzer die Darstellung auf dem
-Bildschirm _anpassen_ kann.
+In diesem Prüfschritt wird die Auszeichnung von Elementen durch Markup nicht beachtet. Es geht also um die mehrgleisige Vermittlung von Informationen **auf dem Bildschirm**. Bei den Prüfkriterien zur richtigen Auszeichnung geht es dagegen darum, dass Informationen **unabhängig** von der Darstellung auf dem Bildschirm verfügbar sind oder dass der Benutzer die Darstellung auf dem Bildschirm **anpassen** kann.
 
 ==== Abgrenzung zu fehlenden Hervorhebungen
 
-In diesem Prüfschritt 9.1.4.1 geht es um die Farbunabhängigkeit _vorhandener_
-Seitenelemente.
+In diesem Prüfschritt 9.1.4.1 geht es um die Farbunabhängigkeit **vorhandener** Seitenelemente.
 
-Eine negative Bewertung ist also beispielsweise angebracht, wenn Links im Text
-oder Menü-Elemente nur durch die Farbe (und nicht zusätzlich durch
-Unterstreichung, Fettung oder andere Markierung) gekennzeichnet sind.
-Wenn Links im Text _überhaupt nicht_ gekennzeichnet sind, ist der
-Prüfschritt dagegen nicht anwendbar.
-Das ist dann vielmehr ein Verstoß gegen Prüfschritt
-ifdef::env_embedded[9.3.2.3 "Konsistente Navigation"]
-ifndef::env_embedded[]
- <<9.3.2.3 Konsistente Navigation.adoc#,9.3.2.3 Konsistente Navigation>>
-endif::env_embedded[]
-bzw.
-ifdef::env_embedded[9.2.4.7 "Aktuelle Position des Fokus deutlich".]
-ifndef::env_embedded[]
-  <<9.2.4.7 Aktuelle Position des Fokus deutlich.adoc#,9.2.4.7 Aktuelle
-  Position des Fokus deutlich>>.
-endif::env_embedded[]
+Eine negative Bewertung ist also beispielsweise angebracht, wenn Links im Text oder Menü-Elemente nur durch die Farbe (und nicht zusätzlich durch Unterstreichung, Fettung oder andere Markierung) gekennzeichnet sind. Wenn Links im Text **überhaupt nicht** gekennzeichnet sind, ist dies zwar nicht nutzerfreundlich, aber wird in diesem Prüfschritt nicht negativ bewertet.
 
-Kennzeichnung der aktuellen Menüposition: Ein Webangebot, das die aktuelle
-Position _überhaupt nicht_ anzeigt, verstößt nicht gegen diesen Prüfschritt
-9.1.4.1.
+Kennzeichnung der aktuellen Menüposition: Ein Webangebot, das die aktuelle Position _überhaupt nicht_ anzeigt, verstößt nicht gegen diesen Prüfschritt 9.1.4.1.
 
 === Einordnung des Prüfschritts nach WCAG 2.1
 

--- a/Prüfschritte/de/9.1.4.1 Ohne Farben nutzbar.adoc
+++ b/Prüfschritte/de/9.1.4.1 Ohne Farben nutzbar.adoc
@@ -216,13 +216,7 @@ Note: This should not in any way discourage the use of color on a page, or
 even color coding if it is redundant with other visual indication.
 ____
 
-(https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)
-
-=== Definieren von Farben
-
-Vordergrundfarbe und Hintergrundfarbe von Text müssen an der selben Stelle definiert werden.
-Sonst kann es zum Beispiel passieren, dass die Farbe der Schrift als Hintergrundfarbe ausgewählt wird und die Schrift nicht mehr zu lesen ist.
-Artikel dazu: http://www.w3.org/QA/Tips/color
+https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html
 
 == Fragen zu diesem Prüfschritt
 

--- a/Prüfschritte/de/9.1.4.1 Ohne Farben nutzbar.adoc
+++ b/Prüfschritte/de/9.1.4.1 Ohne Farben nutzbar.adoc
@@ -4,17 +4,11 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Über Farben vermittelte Informationen sollen auch *ohne* Wahrnehmung der
-Farbe verfügbar sein, also zusätzlich durch andere Mittel (etwa Fettung oder
-Einrückung) hervorgehoben sein.
+Über Farben vermittelte Informationen sollen auch *ohne* Wahrnehmung der Farbe verfügbar sein, also zusätzlich durch andere Mittel (etwa Fettung oder Einrückung) hervorgehoben sein.
 
 == Warum wird das geprüft?
 
-Ausschließlich über Farben vermittelte Informationen sind für blinde Benutzer
-nicht zugänglich.
-Auch farbfehlsichtige Benutzer, die unter Umständen mit
-eigenen Farbschemata arbeiten, können Farben nicht oder nur eingeschränkt
-identifizieren und unterscheiden.
+Ausschließlich über Farben vermittelte Informationen sind für blinde Nutzende nicht zugänglich. Auch farbfehlsichtige Nutzende, die unter Umständen mit eigenen Farbschemata arbeiten, können Farben nicht oder nur eingeschränkt identifizieren und unterscheiden.
 
 == Wie wird geprüft?
 
@@ -26,78 +20,56 @@ Der Prüfschritt ist immer anwendbar.
 
 ==== 2.1 Vermittlung von Informationen über die Farbgebung
 
-Prüfen, ob die Webseite Elemente enthält, die durch Farbgebung Informationen
-vermitteln.
+Prüfen, ob die Webseite Elemente enthält, die durch Farbgebung Informationen vermitteln.
 Beispiele dafür:
 
 * Überschriften werden farblich hervorgehoben
 * Ausgewählte Menueinträge werden in einer anderen Farbe dargestellt
 * Links im Fließtext werden in einer anderen Farbe dargestellt
-* Eine Grafik verwendet unterschiedliche Farben für die vergleichende
-  Darstellung des Kursverlaufs verschiedener Aktien
-* Pflichtfelder in Formularen werden farblich gekennzeichnet (die gelb
-  unterlegten Felder müssen immer ausgefüllt werden)
+* Eine Grafik verwendet unterschiedliche Farben für die vergleichende Darstellung des Kursverlaufs verschiedener Aktien
+* Pflichtfelder in Formularen werden farblich gekennzeichnet (die gelb unterlegten Felder müssen immer ausgefüllt werden)
 
 Solche Hervorhebungen sind positiv.
-Die Vermittlung wichtiger Informationen soll
-sich aber _nicht ausschließlich_ auf _einfache_ Farbänderungen stützen.
-Zu prüfen ist also, ob die Informationen zusätzlich noch auf einem anderen Weg
-vermittelt werden.
+Die Vermittlung wichtiger Informationen soll sich aber **nicht ausschließlich** auf **einfache** Farbänderungen stützen.
+Zu prüfen ist also, ob die Informationen zusätzlich noch auf einem anderen Weg vermittelt werden.
 
 Beispiele für zusätzliche Vermittlung:
 
-* Überschriften sind zusätzlich eingerückt oder durch eine andere
-  Schriftgröße hervorgehoben (das ist fast immer der Fall)
-* Ausgewählte Menueinträge haben einen Kontrastunterschied von mehr als 3:1
-  zur Farbe benachbarter Einträge oder sind durch Einrückung, Fettung,
-  Unterstreichung, zusätzliche Elemente für die Hervorhebung, Änderung der
-  Form des Menü-Eintrags oder dergleichen hervorgehoben.
-* Links im Fließtext sind nicht nur farblich abgesetzt, sondern zusätzlich
-  unterstrichen, gefettet, invertiert oder mit einer Markierung versehen.
-  Ausnahme: Das Kontrastverhältnis zwischen Linkfarbe und umgebender
-  Textfarbe *und* zwischen Linkfarbe und Hintergrund ist 3:1 oder besser.
-  In diesem Fall kann im Ausgangszustand auf die zusätzliche Hervorhebung
-  verzichtet werden.
-  Die Links müssen dann aber bei Fokuserhalt zusätzlich hervorgehoben werden.
-* Linien in Schaubildern sind zusätzlich gestrichelt oder durchgezogen,
-  Flächen haben unterscheidbare Muster
-* Pflichtfelder im Formular sind zusätzlich mit einem Stern mit
-  Bedeutungserklärung am Formularbeginn) oder textlich ("Pflichtfeld")
-  gekennzeichnet
+* Überschriften sind zusätzlich eingerückt oder durch eine andere Schriftgröße hervorgehoben (das ist fast immer der Fall).
+* Ausgewählte Menueinträge haben einen Kontrastunterschied von mehr als 3:1 zur Farbe benachbarter Einträge oder sind durch Einrückung, Fettung, Unterstreichung, zusätzliche Elemente für die Hervorhebung, Änderung der Form des Menü-Eintrags oder dergleichen hervorgehoben.
+* Links im Fließtext sind nicht nur farblich abgesetzt, sondern zusätzlich unterstrichen, gefettet, invertiert oder mit einer Markierung versehen.
+  **Ausnahme:** Das Kontrastverhältnis zwischen Linkfarbe und umgebender Textfarbe ist 3:1 oder besser. In diesem Fall kann im Ausgangszustand auf die zusätzliche Hervorhebung verzichtet werden. Die Links müssen dann aber bei Fokuserhalt zusätzlich hervorgehoben werden.
+* Linien in Schaubildern sind zusätzlich gestrichelt oder durchgezogen, Flächen haben unterscheidbare Muster.
+* Pflichtfelder im Formular sind zusätzlich mit einem Stern mit Bedeutungserklärung am Formularbeginn) oder textlich ("Pflichtfeld")
+  gekennzeichnet.
 
-Ebenfalls andere, zusätzliche Vermittlungswege sind am Beispiel der
-Hervorhebung der aktuell ausgewählten Menüoption:
+Ebenfalls andere, zusätzliche Vermittlungswege sind am Beispiel der Hervorhebung der aktuell ausgewählten Menüoption:
 
 * der Breadcrumb zeigt, welche Seite ausgewählt ist
 * die Überschrift ist stets gleichlautend mit der ausgewählten Menüoption
 
 Ebenfalls nicht als einfache Farbunterschiede gelten:
 
-* die farbige Hinterlegung von Elementen (denn eine Form kommt dazu oder
-  ändert sich)
-* der Austausch von Vorder- und Hintergrundfarbe (denn wenn überhaupt ein
-  Unterschied von Vorder- und Hintergrund wahrgenommen wird, ist auch der
-  Austausch wahrnehmbar)
+* die farbige Hinterlegung von Elementen (denn eine Form kommt dazu oder ändert sich)
+* der Austausch von Vorder- und Hintergrundfarbe (denn wenn überhaupt ein Unterschied von Vorder- und Hintergrund wahrgenommen wird, ist auch der Austausch wahrnehmbar)
 
 === 3. Bewertung
 
 ==== Nicht voll erfüllt
 
-* Fließtextlinks sind von ihrer Textumgebung nur durch abweichende Farbe mit
-  einem Kontrastunterschied von unter 3:1 unterscheidbar.
+* Fließtextlinks sind von ihrer Textumgebung nur durch abweichende Farbe mit einem Kontrastunterschied von unter 3:1 unterscheidbar.
 
 ==== Nicht erfüllt
 
-* Informationen (etwa richtig / falsch) werden lediglich über die Farbe
-  (etwa grün=richtig, rot=falsch) vermittelt.
+* Informationen (etwa richtig / falsch) werden lediglich über die Farbe (etwa grün=richtig, rot=falsch) vermittelt.
 
 == Einordnung des Prüfschritts
 
 === Abgrenzung zu anderen Prüfschritten
 
-==== 1. Abgrenzung zur Prüfung der Kontraste
+==== Abgrenzung zur Prüfung der Kontraste
 
-In diesem Prüfschritt geht es nicht um die Prüfung der Kontraste.
+In diesem Prüfschritt geht es nicht um die Prüfung der Kontraste zum Hintergrund.
 Dies ist Aufgabe der Prüfkriterien
 ifdef::env_embedded[9.1.4.3 "Kontraste von Texten ausreichend"]
 ifndef::env_embedded[]
@@ -111,7 +83,9 @@ ifndef::env_embedded[]
   9.1.4.11 Kontraste von Grafiken und grafischen Bedienelementen ausreichend>>.
 endif::env_embedded[]
 
-==== 2. Abgrenzung zum Prüfschritt 9.1.3.3. Ohne Bezug auf sensorische Merkmale nutzbar
+Für Fließtext-Links gilt ein deutlicher Kontrast (mindestens 3,0:1) der Linkfarbe zur Farbe des umgebenden Textes ausreichend, um diese Anforderung zu erfüllen. Es ist dann keine zusätzliche Hervorhebung nötig. Für die Erfüllung von 9.1.4.3 Kontraste von Texten ausreichend muss jedoch gewährleistet sein, dass die Linkfarbe zum Hintergrund 4,5:1 erfüllt.
+
+==== Abgrenzung zum Prüfschritt 9.1.3.3. Ohne Bezug auf sensorische Merkmale nutzbar
 
 In diesem Prüfschritt geht es nicht um die Prüfung von Verweisen auf
 Seiteninhalte mit Hilfe der Angabe von Farben.
@@ -123,7 +97,7 @@ ifndef::env_embedded[]
 endif::env_embedded[]
 geprüft.
 
-==== 3. Abgrenzung zur Prüfung des Markups
+==== Abgrenzung zur Prüfung des Markups
 
 In diesem Prüfschritt wird die Auszeichnung von Elementen durch Markup nicht
 beachtet.
@@ -133,7 +107,7 @@ dagegen darum, dass Informationen _unabhängig_ von der Darstellung auf dem
 Bildschirm verfügbar sind oder dass der Benutzer die Darstellung auf dem
 Bildschirm _anpassen_ kann.
 
-==== 4. Abgrenzung zu fehlenden Hervorhebungen
+==== Abgrenzung zu fehlenden Hervorhebungen
 
 In diesem Prüfschritt 9.1.4.1 geht es um die Farbunabhängigkeit _vorhandener_
 Seitenelemente.
@@ -246,25 +220,16 @@ ____
 
 === Definieren von Farben
 
-Vordergrundfarbe und Hintergrundfarbe von Text müssen an der selben Stelle
-definiert werden.
-Sonst kann es zum Beispiel passieren, dass die Farbe der Schrift als
-Hintergrundfarbe ausgewählt wird und die Schrift nicht mehr zu lesen ist.
-Artikel dazu:
-http://www.w3.org/QA/Tips/color
+Vordergrundfarbe und Hintergrundfarbe von Text müssen an der selben Stelle definiert werden.
+Sonst kann es zum Beispiel passieren, dass die Farbe der Schrift als Hintergrundfarbe ausgewählt wird und die Schrift nicht mehr zu lesen ist.
+Artikel dazu: http://www.w3.org/QA/Tips/color
 
 == Fragen zu diesem Prüfschritt
 
 === Häufig werden besuchte Links in einer anderen Farbe dargestellt Fällt das auch unter diesen Prüfschritt?
 
-Die Unterscheidung besuchter und nicht besuchter Links ist hilfreich.
-Der Benutzer kann gleich sehen, welche Seiten er schon besucht hat.
-Ideal wäre es daher, wenn besuchte Links zum Beispiel zusätzlich durch eine
-andere Unterstreichung markiert würden.
+Die Unterscheidung besuchter und nicht besuchter Links ist hilfreich. Der Benutzer kann gleich sehen, welche Seiten er schon besucht hat. Ideal wäre es daher, wenn besuchte Links zum Beispiel zusätzlich durch eine andere Unterstreichung markiert würden.
 
-Aber die verfügbaren Gestaltungsmöglichkeiten sind begrenzt.
-Und zu viele unterschiedliche Kennzeichnungen von Links können auch
-Verwirrung stiften.
+Aber die verfügbaren Gestaltungsmöglichkeiten sind begrenzt. Und zu viele unterschiedliche Kennzeichnungen von Links können auch Verwirrung stiften.
 
-In diesem Prüfschritt des BITV-Tests wird die Kennzeichnung besuchter Links
-nicht berücksichtigt, sie ist für die Bewertung nicht relevant.
+In diesem Prüfschritt des BITV-Tests wird die Kennzeichnung besuchter Links nicht berücksichtigt, sie ist für die Bewertung nicht relevant.


### PR DESCRIPTION
- Ausnahme korrigiert: Kontrast von Linkfarbe zur umgebenden Textfarbe muss 3,0:1 haben. Zum Hintergrund muss der Kontrast 4,5:1 sein (nicht wie es in dem Prüfschritt-Text stand 3,0:1).
- Abgrenzung zu diesem Prüfschritt ergänzt: Linkfarbe muss zum Hintergrund 4,5:1 haben. Wird bei 9.1.4.3 geprüft.
- Abgrenzung zu diesem Prüfschritt korrigiert: Wenn es gar keine Hervorhebung bei Links gibt, ist dies nicht nutzerfreundlich, wird aber in diesem Prüfschritt nicht negativ bewertet (auch nicht in Konsistente Navigation oder im Fokusprüfschritt - beide Verweise gelöscht).