### PR TITLE
Update ausgelassene Überschriften Hierarchie-Ebenen kein Fehler nach WCAG

### DIFF
--- a/Prüfschritte/de/9.1.3.1a HTML-Strukturelemente für Überschriften.adoc
+++ b/Prüfschritte/de/9.1.3.1a HTML-Strukturelemente für Überschriften.adoc
@@ -40,7 +40,7 @@ Der Prüfschritt ist anwendbar, wenn es auf der Seite Inhalte gibt, die durch Ü
 
 * Es ist nicht die Aufgabe des Prüfschritts zu prüfen, ob Wortwahl oder Stil der Überschriften den jeweiligen Inhalten angemessen sind.
 * Überschriften sollten nach Möglichkeit korrekt geschachtelt sein (`h1` gefolgt von `h2` gefolgt von `h3`, und so weiter, oder entsprechenden `aria-level`-Attributen auf Elementen mit `role="heading"`), um die Gliederung der Text-Inhalte abzubilden.
-  Das Auslassen von Hierarchie-Ebenen ist kein Fehler, wenn dies die Gliederung der Inhalte dadurch nicht unlogisch gerechtfertigt ist.
+  Das Auslassen von Hierarchie-Ebenen ist an sich kein Fehler, wenn die Gliederung der Inhalte dadurch nicht unlogisch ist.
 * Die erste Regel für den Einsatz von WAI-ARIA empfiehlt, wenn möglich native HTML-Elemente einsetzen. Siehe https://www.w3.org/TR/using-aria/[Using of ARIA, First rule of ARIA use]. Wenn dies nicht möglich ist, kann mit `role="heading"` und dem ``aria-level``-Attribut die Semantik zur Verfügung gestellt werden.
 * Die Inhalte von Iframes werden ebenso überprüft wie andere Seiteninhalte. Dazu muss unter Umständen der Iframe in einem neuen Fenster geladen werden.
 

--- a/Prüfschritte/de/9.1.3.1a HTML-Strukturelemente für Überschriften.adoc
+++ b/Prüfschritte/de/9.1.3.1a HTML-Strukturelemente für Überschriften.adoc
@@ -39,8 +39,7 @@ Der Prüfschritt ist anwendbar, wenn es auf der Seite Inhalte gibt, die durch Ü
 === 3. Hinweise
 
 * Es ist nicht die Aufgabe des Prüfschritts zu prüfen, ob Wortwahl oder Stil der Überschriften den jeweiligen Inhalten angemessen sind.
-* Überschriften sollten nach Möglichkeit korrekt geschachtelt sein (`h1` gefolgt von `h2` gefolgt von `h3`, und so weiter, oder entsprechenden `aria-level`-Attributen auf Elementen mit `role="heading"`), um die Gliederung der Text-Inhalte abzubilden.
-  Das Auslassen von Hierarchie-Ebenen ist an sich kein Fehler, wenn die Gliederung der Inhalte dadurch nicht unlogisch ist.
+* Überschriften sollten korrekt geschachtelt sein (`h1` gefolgt von `h2` gefolgt von `h3`, und so weiter, oder entsprechenden `aria-level`-Attributen auf Elementen mit `role="heading"`), um die Gliederung der Text-Inhalte abzubilden. Das Auslassen von Hierarchie-Ebenen ist aber an sich kein Fehler, solange die hierarchische Abfolge der Überschriften logisch bleibt.
 * Die erste Regel für den Einsatz von WAI-ARIA empfiehlt, wenn möglich native HTML-Elemente einsetzen. Siehe https://www.w3.org/TR/using-aria/[Using of ARIA, First rule of ARIA use]. Wenn dies nicht möglich ist, kann mit `role="heading"` und dem ``aria-level``-Attribut die Semantik zur Verfügung gestellt werden.
 * Die Inhalte von Iframes werden ebenso überprüft wie andere Seiteninhalte. Dazu muss unter Umständen der Iframe in einem neuen Fenster geladen werden.
 

--- a/Prüfschritte/de/9.1.3.1a HTML-Strukturelemente für Überschriften.adoc
+++ b/Prüfschritte/de/9.1.3.1a HTML-Strukturelemente für Überschriften.adoc
@@ -39,8 +39,8 @@ Der Prüfschritt ist anwendbar, wenn es auf der Seite Inhalte gibt, die durch Ü
 === 3. Hinweise
 
 * Es ist nicht die Aufgabe des Prüfschritts zu prüfen, ob Wortwahl oder Stil der Überschriften den jeweiligen Inhalten angemessen sind.
-* Überschriften sollten korrekt geschachtelt sein (`h1` gefolgt von `h2` gefolgt von `h3`, und so weiter, oder entsprechenden `aria-level`-Attributen auf Elementen mit `role="heading"`), um die Gliederung der Text-Inhalte abzubilden.
-  Das Auslassen von Hierarchie-Ebenen muss aber kein Fehler sein, wenn dies durch die Gliederung der Inhalte gerechtfertigt ist.
+* Überschriften sollten nach Möglichkeit korrekt geschachtelt sein (`h1` gefolgt von `h2` gefolgt von `h3`, und so weiter, oder entsprechenden `aria-level`-Attributen auf Elementen mit `role="heading"`), um die Gliederung der Text-Inhalte abzubilden.
+  Das Auslassen von Hierarchie-Ebenen ist kein Fehler, wenn dies die Gliederung der Inhalte dadurch nicht unlogisch gerechtfertigt ist.
 * Die erste Regel für den Einsatz von WAI-ARIA empfiehlt, wenn möglich native HTML-Elemente einsetzen. Siehe https://www.w3.org/TR/using-aria/[Using of ARIA, First rule of ARIA use]. Wenn dies nicht möglich ist, kann mit `role="heading"` und dem ``aria-level``-Attribut die Semantik zur Verfügung gestellt werden.
 * Die Inhalte von Iframes werden ebenso überprüft wie andere Seiteninhalte. Dazu muss unter Umständen der Iframe in einem neuen Fenster geladen werden.
 


### PR DESCRIPTION
Vorschlag zur deutlicheren Formulierung, dass eine ausgelassene Überschriften Hierarchie-Ebenen keinen Fehler nach WCAG darstellt.
Auch wenn ich selbst dies immer als "best practice" in Prüfberichten anmerke, so ist das nach WCAG offiziell kein Fehler. 
Die bisherige Formulierung legt das immer noch nahe.

Siehe auch Artikel "Heading off confusion: When do headings fail WCAG?": 
https://www.tpgi.com/heading-off-confusion-when-do-headings-fail-wcag/