### PR TITLE
9.3.3.3 Hilfe bei Fehlern: Ausnahme bei Sicherheitsrisiko.adoc

### DIFF
--- a/Prüfschritte/de/9.3.3.3 Hilfe bei Fehlern.adoc
+++ b/Prüfschritte/de/9.3.3.3 Hilfe bei Fehlern.adoc
@@ -10,7 +10,7 @@ Wenn ein Formular Fehlermeldungen erzeugt, müssen diese verständlich sein und 
 
 Bei Formulareingaben kommt es öfters zu Fehlern: Nutzer verschreiben sich oder überspringen benötigte Eingaben.
 
-Wenn das Angebot Nutzereingaben überprüft, sollen die ausgegebenen Fehlermeldungen hilfreich sein und es den Nutzern erleichtern, Eingaben zu korrigieren.
+Wenn das Angebot Nutzereingaben überprüft, sollen die ausgegebenen Fehlermeldungen hilfreich sein und es den Nutzenden erleichtern, Eingaben zu korrigieren.
 
 == Wie wird geprüft?
 
@@ -32,12 +32,13 @@ Dies kann schon während der Eingabe oder erst nach dem Abschicken des Formulars
 * Wenn serverseitig eine Fehlermeldung auf einer neuen Seite ausgegeben wird, wird diese wie ein Seitenzustand unter der Ausgangsseite mitgeprüft. Geprüft wird auch die Erfüllung anderer relevanter Prüfkriterien.
 * Bei komplizierten Formaten, z. B. Datum, hilft eine Angabe, in welcher Weise das Datum eingegeben werden soll (z. B. tt.mm.jjjj), um Fehler zu vermeiden.
 * Wenn Formulare keine Fehlermeldungen erzeugen, ist dies nicht negativ zu bewerten.
+* Hinweise, wie genau der Fehler korrigiert werden kann, sind nicht erforderlich, wenn diese die Sicherheit des Inhalts gefährden würden. Fehlermeldungen von Anmelde- und Passwortfeldern müssen beispielsweise keine spezifischen Hinweise enthalten, da dies die Sicherheit des Anmeldevorgangs beeinträchtigen würden.
 
 === 4. Bewertung
 
 ==== Nicht erfüllt
 
-* Fehlermeldungen sind unklar oder irreführend
+* Fehlermeldungen sind unklar oder irreführend.
 
 == Einordnung des Prüfschritts
 


### PR DESCRIPTION
Unter Hinweise Ausnahme bzgl. Fehlermeldungen, die ein sicherheitsrisiko erzeugen würden, hinzugefügt.
Vorschlag: 
> Hinweise, wie genau der Fehler korrigiert werden kann, sind nicht erforderlich, wenn diese die Sicherheit des Inhalts gefährden würden. Zum Beispiel Anmelde- und Passwortfeldern müssen beispielsweise keine spezifischen Hinweise enthalten, da dies die Sicherheit des Anmeldevorgangs beeinträchtigen würden.