### PR TITLE
Update 9.3.3.2 Beschriftungen von Formularelementen vorhanden.adoc

### DIFF
--- a/Prüfschritte/de/9.3.3.2 Beschriftungen von Formularelementen vorhanden.adoc
+++ b/Prüfschritte/de/9.3.3.2 Beschriftungen von Formularelementen vorhanden.adoc
@@ -29,7 +29,7 @@ Die Seite im Firefox oder Chrome Browser aufrufen.
 ==== 2.1 Sind Beschriftungen vorhanden ?
 
 * Sind alle Formularelemente sichtbar beschriftet?
-* Sind Pflichtfelder in ``label``- oder ``legend``-Elementen klar angezeigt? Wenn zur Anzeige Symbole wie etwa ein Sternchen (*) genutzt werden, sollte deren Bedeutung am Beginn des Formulars erklärt sein.
+* Sind Pflichtfelder in ``label``- oder ``legend``-Elementen klar angezeigt? Wenn zur Anzeige Symbole wie etwa ein Sternchen (*) genutzt werden, sollte deren Bedeutung erklärt sein (bestenfalls am Beginn des Formulars, bei einem mehrstufigen Formular beim ersten Formular).
 * Wenn Eingabefelder ein bestimmtes Eingabeformat vorgeben, wird dieses *vor* dem Eingabefeld oder auch im Placeholder-Text klar beschrieben (Beispiele wären "Format der Datumseingabe: TT.MM.JJJJ" oder "Telefonnummer: Nur Zahlen ohne Leerstellen oder Bindestriche eingeben").
 
 ==== 2.2 Sind Beschriftungen richtig positioniert?


### PR DESCRIPTION
Anforderung bzgl. Erklärung des * etwas aufgeweicht: "Wenn zur Anzeige Symbole wie etwa ein Sternchen (*) genutzt werden, sollte deren Bedeutung erklärt sein (bestenfalls am Beginn des Formulars, bei einem mehrstufigen Formular beim ersten Formular)."
Siehe https://github.com/BIK-BITV/BIK-Web-Test/issues/33