### PR TITLE
9.3.3.1 Fehlererkennung: Zusätzlicher Hinweis hinsichtlich unzureichender Unterstützung von aria-errormessage

### DIFF
--- a/Prüfschritte/de/9.3.3.1 Fehlererkennung.adoc
+++ b/Prüfschritte/de/9.3.3.1 Fehlererkennung.adoc
@@ -35,6 +35,7 @@ Der Prüfschritt ist anwendbar, wenn die Seite Formulare enthält, welche bei in
 
 * Wenn serverseitig eine Fehlermeldung auf neuer Seite ausgegeben wird, wird diese wie ein Seitenzustand unter der Ausgangsseite mitgeprüft. Geprüft wird auch die Erfüllung anderer relevanter Prüfkriterien.
 * Wenn Formulare keine Fehlermeldungen erzeugen, ist dies nicht negativ zu bewerten.
+* Die Verknüpfung von Fehlermeldungen mit `aria-errormessage` (siehe https://www.w3.org/TR/wai-aria-1.1/#aria-errormessage[WAI-ARIA 1.1 Spec]) ist bislang noch nicht ausreichend von Browsern unterstützt, um Fehlermeldungen ausreichend zugänglich für Screenreader-Nutzende zu verknüpfen.
 
 === 4. Bewertung
 


### PR DESCRIPTION
Ergänzung eines Hinweises, dass `aria-errormessage` zurzeit von Browsern noch nicht ausreichend unterstützt wird, um bei der Verknüpfung von Fehlermeldungen `aria-describedby` zu ersetzen.

closes #253 
