### PR TITLE
5.4 Erhaltung von Barrierefreiheitsinformationen bei Konvertierung: Anwendbarkeit bei Konvertierung von HTML-Ziel- und Quellformat entfernt

### DIFF
--- a/Prüfschritte/de/5.4 Erhaltung von Barrierefreiheitsinformationen bei Konvertierung.adoc
+++ b/Prüfschritte/de/5.4 Erhaltung von Barrierefreiheitsinformationen bei Konvertierung.adoc
@@ -28,7 +28,7 @@ Die Prüfung ist sehr individuell und richtet sich nach den verwendeten Quell- u
 
 === 3. Hinweise
 
-Da die Prüfung eines Nicht-HTML-Formats nicht mit diesem Prüfverfahren erfolgen kann, muss der Prüfschritt mit "nicht anwedbar" bewertet werden. Es sollte jedoch in einer Anmerkungen darauf hingewiesen werden, dass die Barrierefreiheits-Informationen (z.B. semantische Überschriften, Links oder Untertitel) im Zielformat erhalten bleiben sollen.
+Da die Prüfung eines Nicht-HTML-Formats nicht mit diesem Prüfverfahren erfolgen kann, muss der Prüfschritt mit "nicht anwendbar" bewertet werden. Es sollte jedoch in einer Anmerkungen darauf hingewiesen werden, dass die Barrierefreiheits-Informationen (z.B. semantische Überschriften, Links oder Untertitel) im Zielformat erhalten bleiben sollen.
 
 === 4. Bewertung
 

--- a/Prüfschritte/de/5.4 Erhaltung von Barrierefreiheitsinformationen bei Konvertierung.adoc
+++ b/Prüfschritte/de/5.4 Erhaltung von Barrierefreiheitsinformationen bei Konvertierung.adoc
@@ -17,28 +17,28 @@ Hinzunehmen ist der Verlust von Barrierefreiheitsinformationen nur dann, wenn da
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist grundsätzlich anwendbar, wenn die Webseite digitale Formate wie Text, Audio und Video konvertiert. Der Prüfschritt ist jedoch im BIK Web-Test nur anwendbar, wenn sowohl Start- als auch Zielformat HTML ist. Sind entweder das Ausgangs- oder das Zielformat der Konvertierung nicht HTML, kann der Prüfschritt nicht in diesem Verfahren allein geprüft werden, denn hier müsste zusätzlich eine Prüfung des abweichenden Formats durchgeführt werden.
+Der Prüfschritt ist grundsätzlich anwendbar, wenn die Webseite digitale Formate wie Text, Audio und Video konvertiert. Sind jedoch entweder das Ausgangs- oder das Zielformat der Konvertierung nicht HTML, kann der Prüfschritt nicht in diesem Verfahren allein geprüft werden, denn hier müsste zusätzlich eine Prüfung des abweichenden Formats durchgeführt werden. Hinsichtlich der Bewertung siehe "3. Hinweise".
 
 === 2. Prüfung
 
-Die Prüfung ist sehr individuell und richtet sich nach den verwendeten Quell- und Zielformaten.
+Die Prüfung ist sehr individuell und richtet sich nach den verwendeten Quell- und Zielformaten. Die zusätzliche Prüfung des abweichenden Formats kann nicht im Rahmen dieses Prüfverfahrens durchgeführt werden.
 
-. Gegebenenfalls Beispieldokumente mit Barrierefreiheits-Informationen in ein HTML-Zielformat konvertieren. 
+. Gegebenenfalls Beispieldokumente mit Barrierefreiheits-Informationen in das Zielformat konvertieren. 
 . Sind vom Format grundsätzlich unterstützte Barrierefreiheits-Informationen nach der Konvertierung im Zielformat erhalten geblieben? 
 
 === 3. Hinweise
 
-Bei Konvertierung in ein Nicht-HTML-Format sollte in die Anmerkungen aufgenommen werden, dass die Barrierefreiheits-Informationen (z.B. semantische Überschriften, Links oder Untertitel) im Zielformat erhalten bleiben sollen.
+Da die Prüfung eines Nicht-HTML-Formats nicht mit diesem Prüfverfahren erfolgen kann, muss der Prüfschritt mit "nicht anwedbar" bewertet werden. Es sollte jedoch in einer Anmerkungen darauf hingewiesen werden, dass die Barrierefreiheits-Informationen (z.B. semantische Überschriften, Links oder Untertitel) im Zielformat erhalten bleiben sollen.
 
 === 4. Bewertung
 
 ==== Erfüllt
 
-Das HTML-Zielformat enthält alle Barrierefreiheits-Informationen des HTML-Ausgangsformats, die grundsätzlich unterstützt werden.
+Das Zielformat enthält alle Barrierefreiheits-Informationen des HTML-Ausgangsformats, die grundsätzlich unterstützt werden.
 
 ==== Nicht voll erfüllt
 
-Grundsätzlich vom HTML-Zielformat unterstützte Barrierefreiheits-Informationen des HTML-Ausgangsformats gehen bei der Konvertierung verloren.
+Grundsätzlich vom Zielformat unterstützte Barrierefreiheits-Informationen des HTML-Ausgangsformats gehen bei der Konvertierung verloren.
 
 == Einordnung des Prüfschritts
 


### PR DESCRIPTION
- Konvertierung meint Überführung in ein anderes Dateiformat. Der Hinweis, dass nur die Prüfung der Konvertierung von HTML-Quell- und Zielformat im Verfahren möglich sei, wurde entfernt, da es sich bei gleichem Quell- und Zielformat nicht um eine Konvertierung handelt.
- Die Prüfanleitung wurde erst einmal beibehalten, da die Prüfung ja grundsätzlich möglich ist, nur eben nicht in unserem Verfahren. Die Prüfanleitung wurde jedoch auch mit dem Hinweis ergänzt, dass in unserem Verfahren konvertierte Formate nicht geprüft werden können.
- Unter "3. Hinweise" wurde aufgenommen, dass der Prüfschritt auf "nicht anwendbar" gesetzt werden muss. Der Hinweis, dass dem Kunden in einer Anmerkung die Anforderung mitgegeben werden soll, wurde beibehalten.