### PR TITLE
7.1.4 Untertitel-Anpassungen: Unbedeutende sprachliche Änderung

### DIFF
--- a/Prüfschritte/de/7.1.4 Untertitel-Anpassungen.adoc
+++ b/Prüfschritte/de/7.1.4 Untertitel-Anpassungen.adoc
@@ -4,7 +4,7 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Wenn das Webangebot Videos mit Untertiteln überträgt, lassen sich Untertitel anpassen, z.B. hinsichtlich der Schriftgöße.
+Wenn das Webangebot Videos mit Untertiteln enthält, lassen sich Untertitel anpassen, z.B. hinsichtlich der Schriftgöße.
 
 == Warum wird das geprüft?
 


### PR DESCRIPTION
Kleinere sprachliche Änderung, die keine inhaltliche Auswirkung hat.