### PR TITLE
9.1.4.5 Verzicht auf Schriftgrafiken: Nicht anwendbar als Bewertungsoption ergänzt

### DIFF
--- a/Prüfschritte/de/9.1.4.5 Verzicht auf Schriftgrafiken.adoc
+++ b/Prüfschritte/de/9.1.4.5 Verzicht auf Schriftgrafiken.adoc
@@ -21,7 +21,7 @@ Und bei Zoomvergrößerung werden die Schriftkanten unscharf.
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist immer anwendbar.
+Der Prüfschritt ist anwendbar, wenn das Webangebot Schriftgrafiken enthält.
 
 === 2. Prüfung
 


### PR DESCRIPTION
1. Anwendbar des Prüfschritts: Von "Immer anwendbar" auf "Anwendbar, wenn das Webangebot Schriftgrafiken enthält" geändert.