### PR TITLE
9.2.1.1 Ohne Maus nutzbar: Nicht anwendbar als Bewertungsoption ergänzt

### DIFF
--- a/Prüfschritte/de/9.2.1.1 Ohne Maus nutzbar.adoc
+++ b/Prüfschritte/de/9.2.1.1 Ohne Maus nutzbar.adoc
@@ -25,7 +25,7 @@ eingeschränkte Menschen oder Blinde.
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist immer anwendbar.
+Der Prüfschritt ist anwendbar, wenn der Webauftritt interaktive Elemente enthält.
 
 === 2. Prüfung
 


### PR DESCRIPTION
1. Anwendbarkeit des Prüfschritts: "Immer anwendbar" geändert in "Der Prüfschritt ist anwendbar, wenn der Webauftritt interaktive Elemente enthält." (Konsistent zu "Focus Order" und "Focus Visible")