### PR TITLE
9.3.2.1 Keine unerwartete Kontextänderung bei Fokus: Nicht anwendbar als Bewertungsoption ergänzt

### DIFF
--- a/Prüfschritte/de/9.3.2.1 Keine unerwartete Kontextänderung bei Fokus.adoc
+++ b/Prüfschritte/de/9.3.2.1 Keine unerwartete Kontextänderung bei Fokus.adoc
@@ -29,7 +29,7 @@ falsche Fenster (mit der Historie der bislang besuchten Seiten) geschlossen.
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist immer anwendbar.
+Der Prüfschritt ist anwendbar, wenn der Webauftritt interaktive Elemente enthält.
 
 === 2. Prüfung
 


### PR DESCRIPTION
1. Anwendbarkeit des Prüfschritts: "Immer anwenbar" in "Anwendbar, wenn der Webauftritt interaktive Elemente enthält". (Konsistent zu "Fokus Order", "Focus Visible")