### PR TITLE
9.2.2.2 Bewegte Inhalte abschaltbar: Prüfung

### DIFF
--- a/Prüfschritte/de/9.2.2.2 Bewegte Inhalte abschaltbar.adoc
+++ b/Prüfschritte/de/9.2.2.2 Bewegte Inhalte abschaltbar.adoc
@@ -69,9 +69,8 @@ animierte Werbung:
 . Prüfen, ob das Aktivieren der Schaltfläche oder des Tastatur-Shortcuts die
   Bewegung tatsächlich anhält und sie auch nicht wieder von allein erneut
   beginnt.
-. Prüfen, ob das erneute Aktivieren der Schaltfläche die Bewegung wieder in
-  Gang setzt, und zwar von dem Punkt aus, der beim letztem Anhalten erreicht
-  war.
+  
+Zusätzlich sollte geprüft werden, ob das erneute Aktivieren der Schaltfläche die Bewegung wieder in Gang setzt, und zwar (bei Videos oder Animationen) von dem Punkt aus, der beim letztem Anhalten erreicht wurde. Ist dies nicht der Fall, sollte dies angemerkt werden, ist aber nicht als Verstoß gegen diese Anforderung zu verstehen.
 
 === 3. Hinweise
 

--- a/Prüfschritte/de/9.2.2.2 Bewegte Inhalte abschaltbar.adoc
+++ b/Prüfschritte/de/9.2.2.2 Bewegte Inhalte abschaltbar.adoc
@@ -70,7 +70,7 @@ animierte Werbung:
   Bewegung tatsächlich anhält und sie auch nicht wieder von allein erneut
   beginnt.
   
-Zusätzlich sollte geprüft werden, ob das erneute Aktivieren der Schaltfläche die Bewegung wieder in Gang setzt, und zwar (bei Videos oder Animationen) von dem Punkt aus, der beim letztem Anhalten erreicht wurde. Ist dies nicht der Fall, sollte dies angemerkt werden, ist aber nicht als Verstoß gegen diese Anforderung zu verstehen.
+Zusätzlich sollte geprüft werden, ob das erneute Aktivieren der Schaltfläche die Bewegung wieder in Gang setzt, und zwar (bei Videos oder Animationen) von dem Punkt aus, der beim letztem Anhalten erreicht wurde. Ist das nicht der Fall, sollte dies angemerkt werden. Dieser Mangel ist aber nicht als Verstoß gegen die Anforderung dieses Prüfschritts zu verstehen.
 
 === 3. Hinweise
 


### PR DESCRIPTION
Anpassung des letzten Punkts der Prüfung. Ist die Bewegung nach Stoppen nicht mehr erneut aktivierbar, ist das ggf. ein Bug und/oder ein Usability-Problem, aber keine normative Anforderung im Sinne dieses Prüfschritts.