### PR TITLE
9.1.4.12 Textabstände anpassbar - Ausnahmen, Bewertung

### DIFF
--- a/Prüfschritte/de/9.1.4.12 Textabstände anpassbar.adoc
+++ b/Prüfschritte/de/9.1.4.12 Textabstände anpassbar.adoc
@@ -42,6 +42,13 @@ der nicht über eine Grafik bereitgestellt wird).
   Wortabstand werden auf die maximal geforderten Werte gesetzt.
 . Prüfen, ob es durch die neuen Werte zum Abschneiden oder Überlappen von Text
   oder den Verlust von Funktionalität kommt.
+  
+=== 3. Hinweise
+* Die Anforderung ist nicht anwendbar ist auf Elemente wie `input type="file"`, auf die CSS-Anpassungen keine Auswirkung haben.
+
+=== 4. Bewertung
+==== Erfüllt:
+* Nach Anwendung des Bookmarklets sind alle Texte, auch in Ausklappbereichen und Menüs, vollständig lesbar, Sie sind nicht abgeschnitten und überlagern keine anderen Inhalte.
 
 == Einordnung des Prüfschritts
 


### PR DESCRIPTION
* Ergänzung eines Hinweises, dass die Anforderung nicht anwendbar ist auf Elemente wie `input type="file"`, auf die CSS-Anpassungen keine Auswirkung haben.
* Ergänzung eines Abschnitts "Bewertung"

Closes #325 