### PR TITLE
9.1.4.10 Inhalte brechen um - Ausnahme select-Optionen

### DIFF
--- a/Prüfschritte/de/9.1.4.10 Inhalte brechen um.adoc
+++ b/Prüfschritte/de/9.1.4.10 Inhalte brechen um.adoc
@@ -65,6 +65,7 @@ Die Prüfung bezieht sich auf Web-Inhalte mit horizontal verlaufender Schrift.
   erforderlich ist, sind Inhalte, deren Nutzung ein zweidimensionales Layout
   voraussetzen, etwa Datentabellen, Bilder, Diagramme, Videos, Spiele oder
   Benutzerschnittstellen mit Werkzeugleisten.
+* Optionen in geöffneten `select`-Elementen, die nicht in den reduzierten Viewport passen, gelten nicht als Fehler im Sinne dieses Prüfschritts.
 * Im Prüfschritt wird nicht geprüft, ob die Zoomvergrößerung auf 400%
   Textinhalte tatsächlich auf 400% oder einen geringeren Wert vergrößert.
   Dies ist Gegenstand von Prüfschritt


### PR DESCRIPTION
Unter 3. Hinweise hinzugefügt: Optionen in geöffneten `select`-Elementen, die nicht in den reduzierten Viewport passen, gelten nicht als Fehler im Sinne dieses Prüfschritts.

Siehe Diskussion in https://github.com/w3c/wcag/issues/2275

Closes #256 
