### PR TITLE
9.1.4.1 Ohne Farben nutzbar: Verallgemeinerung

### DIFF
--- a/Prüfschritte/de/9.1.4.1 Ohne Farben nutzbar.adoc
+++ b/Prüfschritte/de/9.1.4.1 Ohne Farben nutzbar.adoc
@@ -37,7 +37,7 @@ Beispiele für zusätzliche Vermittlung:
 
 * Überschriften sind zusätzlich eingerückt oder durch eine andere Schriftgröße hervorgehoben (das ist fast immer der Fall).
 * Ausgewählte Menueinträge haben einen Kontrastunterschied von mehr als 3:1 zur Farbe benachbarter Einträge oder sind durch Einrückung, Fettung, Unterstreichung, zusätzliche Elemente für die Hervorhebung, Änderung der Form des Menü-Eintrags oder dergleichen hervorgehoben.
-* Links im Fließtext sind nicht nur farblich abgesetzt, sondern zusätzlich unterstrichen, gefettet, invertiert oder mit einer Markierung versehen.
+* Links im Fließtext sind nicht nur farblich abgesetzt, sondern durch ein weiteres visuelles Merkmal unterschieden: z.B. zusätzlich unterstrichen, gefettet oder kursiv, invertiert oder mit einer Markierung versehen.
   **Ausnahme:** Das Kontrastverhältnis zwischen Linkfarbe und umgebender Textfarbe ist 3:1 oder besser. In diesem Fall kann im Ausgangszustand auf die zusätzliche Hervorhebung verzichtet werden. Die Links müssen dann aber bei Fokuserhalt zusätzlich hervorgehoben werden.
 * Linien in Schaubildern sind zusätzlich gestrichelt oder durchgezogen, Flächen haben unterscheidbare Muster.
 * Pflichtfelder im Formular sind zusätzlich mit einem Stern mit Bedeutungserklärung am Formularbeginn) oder textlich ("Pflichtfeld")


### PR DESCRIPTION
Der Text zur Unterschiedung von Fließtextlinks nicht nur über Farbe wurde verallgemeinert auf "weiteres visuelles Merkmal": es muss nicht Fettung sein.

Closes #216