### PR TITLE
9.2.4.7 Aktuelle Position des Fokus deutlich - Bezug zu 9.1.4.11

### DIFF
--- a/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
+++ b/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
@@ -52,13 +52,8 @@ Der Prüfschritt ist anwendbar, wenn die Seite interaktive Elemente enthält.
 . Wenn nur der Standard-Browser-Tastaturfokus (Systemkranz) erscheint,
   prüfen, ob dieser an dieser vor gestalteten (also etwa über CSS
   gefärbten) Hintergründen gut zu erkennen ist.
-. In Zweifelsfällen gemäß Prüfschritt
-ifdef::env_embedded[9.1.4.3 "Kontraste von Texten ausreichend"]
-ifndef::env_embedded[]
-  <<9.1.4.3 Kontraste von Texten ausreichend.adoc#,9.1.4.3 Kontraste von
-  Texten ausreichend>>
-endif::env_embedded[]
-  ermitteln, ob der Kontrastabstand zwischen Systemfokus und Hintergrund
+. In Zweifelsfällen gemäß Prüfschritt <<9.1.4.11 Kontraste von Grafiken und grafischen Bedienelementen ausreichend.adoc#,9.1.4.11 Kontraste von Grafiken und grafischen Bedienelementen ausreichend>> bzw. <<9.1.4.3 Kontraste von Texten ausreichend.adoc#,9.1.4.3 Kontraste von
+  Texten ausreichend>> ermitteln, ob der Kontrastabstand zwischen Systemfokus und Hintergrund
   mindestens 3:1 beträgt
 . Seite im Chrome Browser laden und die Schritte 2-7 wiederholen.
 


### PR DESCRIPTION
Bezüglich Messung des Kontrastunterschieds fokussiert/nichtfokussiert gab es bislang nur den Hinweis auf 9.1.4.3, der nur für Hervorhebungen über Änderungen ausschließlich über Textkontrastunterschied gelten würde (Anforderung 4.5:1). Ein Hinweis auf den Grafikkontraste-Prüfschritt 9.1.4.11 (hier Anforderung eines Kontrastunterschiedes von 3:1) wurde ergänzt.