### PR TITLE
9.2.4.3 Schlüssige Reihenfolge bei der Tastaturbedienung: Verlinkungen korrigiert

### DIFF
--- a/Prüfschritte/de/9.2.4.3 Schlüssige Reihenfolge bei der Tastaturbedienung.adoc
+++ b/Prüfschritte/de/9.2.4.3 Schlüssige Reihenfolge bei der Tastaturbedienung.adoc
@@ -39,12 +39,11 @@ Der Prüfschritt ist anwendbar, wenn die Seite Links, Formularelemente oder Obje
 Wenn Inhalte dynamisch generiert werden (also Interaktionen auf der Seite Inhalte hinzufügen, die nicht schon in der Ansicht ohne CSS auf der frisch geladenen Seite sichtbar sind):
 
 . Seite im
-  https://www.bitvtest.de/bitv_test/das_testverfahren_im_detail/werkzeugliste.html#c1078[
+  https://www.bitvtest.de/bitv_test/das_testverfahren_im_detail/werkzeugliste.html#firefox[
   Firefox] aufrufen.
 . Voreinstellung im Firefox: Im Browser-Menü _Einstellungen_ wählen. Dort im Bereich "Surfen" die Option "Markieren von Text mit der Tastatur zulassen" auswählen. Hierdurch wird die Cursor-Position als blinkende Einfügemarke angezeigt. Dies entspricht in der Regel dem Screenreader-Fokus.
 . Dynamisch eingefügte Inhalte aufrufen, etwa durch Formulareingabe oder Auslösen einer Schaltfläche.
-. https://www.bitvtest.de/bitvtest/das_testverfahren_im_detail/werkzeugliste.html#fb[
-  Browsereigenes Entwicklerwerkzeug] (_Inspektor_ für Firefox) aufrufen, das Element-Symbol (das Icon zeigt den Cursor auf einer Taste) links in der Menüleiste auswählen und den eingefügten Inhalt anklicken.
+. Browsereigenes Entwicklerwerkzeug (_Inspektor_ für Firefox) aufrufen, das Element-Symbol (das Icon zeigt den Cursor auf einer Taste) links in der Menüleiste auswählen und den eingefügten Inhalt anklicken.
   Im eingeblendeten Fenster lässt sich nun der generierte Quellcode im Zusammenhang einsehen.
 . Position des eingefügten Elements prüfen.
 +


### PR DESCRIPTION
1. Fehlerhafte Verlinkung im Text korrigiert.
2. Verlinkung auf nicht mehr vorhandenes Ziel (?) entfernt. An anderen Stellen wird ebenfalls nicht auf die browsereigenes Entwicklerwerkzeug verlinkt.