### PR TITLE
9.3.2.1 Keine unerwartete Kontextänderung bei Fokus: Verlinkung korrigiert

### DIFF
--- a/Prüfschritte/de/9.3.2.1 Keine unerwartete Kontextänderung bei Fokus.adoc
+++ b/Prüfschritte/de/9.3.2.1 Keine unerwartete Kontextänderung bei Fokus.adoc
@@ -34,7 +34,7 @@ Der Prüfschritt ist anwendbar, wenn der Webauftritt interaktive Elemente enthä
 === 2. Prüfung
 
 . Seite im
-https://www.bitvtest.de/bitv_test/das_testverfahren_im_detail/werkzeugliste.html#c1078[
+https://www.bitvtest.de/bitv_test/das_testverfahren_im_detail/werkzeugliste.html#firefox[
 Firefox] aufrufen. Das Laden der Seite sollte kein neues Fenster öffnen.
 . Mit der Tabulatortaste die Links und Formularelemente durchgehen.
 . Der Fokuserhalt soll keine automatischen Kontextänderungen (etwa Pop-up-Fenster


### PR DESCRIPTION
Fehlerhafte Verlinkung im Text korrigiert.