### PR TITLE
9.1.2.3 Audiodeskription oder Volltext-Alternative für Videos - "Hinweis" von 9.1.2.2 nach 9.1.2.3 übertragen

### DIFF
--- a/Prüfschritte/de/9.1.2.2 Aufgezeichnete Videos mit Untertiteln.adoc
+++ b/Prüfschritte/de/9.1.2.2 Aufgezeichnete Videos mit Untertiteln.adoc
@@ -49,18 +49,7 @@ ifndef::env_embedded[]
   Audiodeskription oder Volltext-Alternative für Videos>>).
 endif::env_embedded[]
 
-=== 3. Hinweis
-
-Die Anforderung 9.1.2.3 Audiodeskription oder Volltextalternative ist in den WCAG der Konformitätsstufe A zugeordnet. Auf Konformitätstufe AA gibt es ein Erfolgskriterium, das  die Volltext-Alternative nicht akzeptiert. Der BITV-Test prüft dieses Erfolgskriterium der Stufe AA im Prüfschritt 
-ifdef::env_embedded[9.1.2.5 Audiodeskription für Videos]
-ifndef::env_embedded[]
-  <<9.1.2.5 Audiodeskription für Videos.adoc#,9.1.2.5
-  Audiodeskription für Videos>>.
-endif::env_embedded[]
-
-Bietet die Website eine Volltextalternative, so ist zwar 9.1.2.3 (A) erfüllt, nicht aber 9.1.2.5 (AA). Da der BITV-Test Konformität auf Stufe AA prüft, wird dann die Seite in der Auswertung des Tests als "nicht konform" bewertet. Eine Audiodeskription ist also für eine konforme Bewertung der Seite im BITV-Test gefordert, sofern der Prüfschritt anwendbar ist.
-
-=== 4. Bewertung
+=== 3. Bewertung
 
 ==== Erfüllt
 

--- a/Prüfschritte/de/9.1.2.3 Audiodeskription oder Volltext-Alternative für Videos.adoc
+++ b/Prüfschritte/de/9.1.2.3 Audiodeskription oder Volltext-Alternative für Videos.adoc
@@ -69,7 +69,13 @@ Es wird eine Sicht- und Hörprüfung vorgenommen:
 
 . Falls interaktive Elemente vorkommen (z. B. „Aktivieren Sie jetzt, um die Frage zu beantworten“), sollte die Volltextalternative Links oder ähnliches vorsehen, um dieselbe Funktionalität zu gewährleisten.
 
-=== 3. Bewertung
+=== 3. Hinweis
+
+Die Anforderung 9.1.2.3 Audiodeskription oder Volltextalternative ist in den WCAG der Konformitätsstufe A zugeordnet. Auf Konformitätstufe AA gibt es ein Erfolgskriterium, das die Volltext-Alternative nicht akzeptiert. Der BITV-Test prüft dieses Erfolgskriterium der Stufe AA im Prüfschritt 9.1.2.5 Audiodeskription für Videos.
+
+Bietet die Website eine Volltextalternative, so ist zwar 9.1.2.3 (A) erfüllt, nicht aber 9.1.2.5 (AA). Da der BITV-Test Konformität auf Stufe AA prüft, wird dann die Seite in der Auswertung des Tests als "nicht konform" bewertet. Eine Audiodeskription ist also für eine konforme Bewertung der Seite im BITV-Test gefordert, sofern der Prüfschritt anwendbar ist.
+
+=== 4. Bewertung
 
 ==== Nicht voll erfüllt
 

--- a/Prüfschritte/de/9.1.2.3 Audiodeskription oder Volltext-Alternative für Videos.adoc
+++ b/Prüfschritte/de/9.1.2.3 Audiodeskription oder Volltext-Alternative für Videos.adoc
@@ -71,7 +71,12 @@ Es wird eine Sicht- und Hörprüfung vorgenommen:
 
 === 3. Hinweis
 
-Die Anforderung 9.1.2.3 Audiodeskription oder Volltextalternative ist in den WCAG der Konformitätsstufe A zugeordnet. Auf Konformitätstufe AA gibt es ein Erfolgskriterium, das die Volltext-Alternative nicht akzeptiert. Der BITV-Test prüft dieses Erfolgskriterium der Stufe AA im Prüfschritt 9.1.2.5 Audiodeskription für Videos.
+Die Anforderung 9.1.2.3 Audiodeskription oder Volltextalternative ist in den WCAG der Konformitätsstufe A zugeordnet. Auf Konformitätstufe AA gibt es ein Erfolgskriterium, das  die Volltext-Alternative nicht akzeptiert. Der BITV-Test prüft dieses Erfolgskriterium der Stufe AA im Prüfschritt 
+ifdef::env_embedded[9.1.2.5 Audiodeskription für Videos]
+ifndef::env_embedded[]
+  <<9.1.2.5 Audiodeskription für Videos.adoc#,9.1.2.5
+  Audiodeskription für Videos>>.
+endif::env_embedded[]
 
 Bietet die Website eine Volltextalternative, so ist zwar 9.1.2.3 (A) erfüllt, nicht aber 9.1.2.5 (AA). Da der BITV-Test Konformität auf Stufe AA prüft, wird dann die Seite in der Auswertung des Tests als "nicht konform" bewertet. Eine Audiodeskription ist also für eine konforme Bewertung der Seite im BITV-Test gefordert, sofern der Prüfschritt anwendbar ist.
 


### PR DESCRIPTION
Der Abschnitt "Hinweis" der den Umstand erklärt, dass es ein A und AA-Kriterium für das Thema Audiodeskription gibt, war fälschlich 9.1.2.2 zugeordent. Er wurde bei 9.1.2.2 gelöscht und bei 9.1.2.3 eingefügt.
