### PR TITLE
9.1.4.11 Kontraste von Grafiken und grafischen Bedienelementen ausrei…

### DIFF
--- a/Prüfschritte/de/9.1.4.11 Kontraste von Grafiken und grafischen Bedienelementen ausreichend.adoc
+++ b/Prüfschritte/de/9.1.4.11 Kontraste von Grafiken und grafischen Bedienelementen ausreichend.adoc
@@ -57,7 +57,7 @@ Im Zweifelsfall immer den Color Contrast Analyzer einsetzen.
 
 ==== 2.1 Prüfung nicht festgelegter Farben
 
-. Prüfung, ob für Grafiken oder Bedienelemente (etwa Icon-Fonts), für die
+. Prüfung, ob für Grafiken oder Bedienelemente (etwa Icon Fonts), für die
   über CSS eine Vordergrundfarbe festgelegt wurde, auch eine Hintergrundfarbe
   festgelegt ist (und umgekehrt).
 . Das Bookmarklet


### PR DESCRIPTION
9.1.4.11 Kontraste von Grafiken und grafischen Bedienelementen ausreichend - Angleichung Schreibweise "Icon-Fonts" an die ansonsten überall verwendete Schreibweise "Icon Fonts"