### PR TITLE
7.1.5 Gesprochene Untertitel - Textkorrekturen

### DIFF
--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -12,7 +12,7 @@ als akustische Ausgabe zugänglich sein,
 z.B. über eine eigene Tonspur, die den Untertiteln entspricht, 
 oder über eine generierte Sprachausgabe der Untertitel. 
 Nicht programmatisch ermittelbar sind Untertitel, 
-die "fest eingebrannt", also Teil der Bildinformation, sind.
+die "fest eingebrannt" (open captions), also Teil der Bildinformation, sind.
 
 == Warum wird das geprüft?
 

--- a/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
+++ b/Prüfschritte/de/7.1.5 Gesprochene Untertitel.adoc
@@ -6,11 +6,11 @@ include::include/attributes.adoc[]
 
 Wenn das Webangebot Videos mit einem Orginalton enthält, 
 der nicht der Hauptsprache des Webangebots entspricht, 
-sollen zuschaltbaren bzw. programmatisch ermittelbaren Untertitel, 
+sollen zuschaltbare bzw. programmatisch ermittelbare Untertitel, 
 die in der Hauptsprache der Seite angeboten werden, 
 als akustische Ausgabe zugänglich sein, 
 z.B. über eine eigene Tonspur, die den Untertiteln entspricht, 
-oder über eine gnerierte Sprachausgabe der Untertitel. 
+oder über eine generierte Sprachausgabe der Untertitel. 
 Nicht programmatisch ermittelbar sind Untertitel, 
 die "fest eingebrannt", also Teil der Bildinformation, sind.
 
@@ -30,8 +30,7 @@ Der Prüfschritt ist anwendbar:
 * wenn der Original-Ton des Videos fremdsprachig ist 
 (d.h. er entspricht nicht der Hauptsprache des Webauftritts)
 * und Untertitel in der Hauptsprache des Webauftritts bereitgestellt werden
-* und wenn es keine Version des Videos 
-mit einer Tonspur in der Hauptsprache des Webauftritts gibt.
+* und wenn es keine Version des Videos mit einer Tonspur in der Hauptsprache des Webauftritts gibt.
 
 === 2. Prüfung
 


### PR DESCRIPTION
7.1.5 Gesprochene Untertitel - Textkorrekturen, Ergänzung konkreter Bezeichnung "open captions" zur Vermeidung von Missverständlichkeit mangels fachlicher Bezeichnung

version:patch
changelog:fixed