### PR TITLE
9.2.4.6 Aussagekräftige Überschriften und Beschriftungen: Korrektur von Syntaxfehler

### DIFF
--- a/Prüfschritte/de/9.2.4.6 Aussagekräftige Überschriften und Beschriftungen.adoc
+++ b/Prüfschritte/de/9.2.4.6 Aussagekräftige Überschriften und Beschriftungen.adoc
@@ -43,7 +43,6 @@ Besonders in Fachanwendungen gibt es häufiger Beschriftungen und Überschriften
 * Überschriften oder Beschriftungen sind obskur oder schwer verständlich (z.B. unübersetzt)
 * Durch Flüchtigkeits- oder Kopierfehler haben Formularelemente unrichtige, nicht zutreffende Beschriftungen
 * Bestimmte Eingabeformate sind für valide Eingaben erforderlich, werden aber nicht über zusätzliche Beschriftungen vermittelt
-=======
 * Besonders in Fachanwendungen gibt es Labels und Überschriften, die in dem betreffenden Nutzerkreis bestimmten, 
 etablierten Vokabularen entsprechen (einschließlich viel genutzter Abkürzungen). 
 Die Verwendung fachspezifischer Beschriftungen bringt Vorteile mit sich (Wiedererkennbarkeit, Präzision, Kürze), 


### PR DESCRIPTION
In Mitten der Liste befand sich der String `=======`, durch welchen der Rest des Prüfschritts nicht richtig ausgegeben wurde. 

Soweit ich sehen konnte, ist das Überbleibsel eines misslungenen Merges, daher habe ich es einfach entfernt.

