### PR TITLE
9.2.5.7 Ziehbewegungen: Anwendbarkeit

### DIFF
--- a/Prüfschritte/de/9.2.5.7 Ziehbewegungen.adoc
+++ b/Prüfschritte/de/9.2.5.7 Ziehbewegungen.adoc
@@ -17,7 +17,7 @@ ein Aktions-Menü die Auswahl des Zielorts.
 
 === 1. Anwendbarkeit des Prüfschritts
 
-Der Prüfschritt ist anwendbar, wenn Funktionen mit Hilfe von Ziehbewegungen (Ziehen und Ablegen) ausgeführt werden müssen.
+Der Prüfschritt ist anwendbar, wenn Funktionen mit Hilfe von Ziehbewegungen (Ziehen und Ablegen, Verschieben) auf der Seite vorhanden sind.
 
 === 2. Prüfung
 


### PR DESCRIPTION
Zwei kleine Textänderungen: 

1. Anwendbar, sobald Ziehbewegungen implementiert sind, egal, ob sie genutzt werden **müssen** (das wäre ja ein Fail) oder Alternativen vorhanden sind.
2. Nicht nur Ziehen u. Ablegen (Drag'n Drop) sondern auch Verschieben, wo dieses nicht pfadgebunden ist