### PR TITLE
9.2.5.8 Zielgröße (Minimum) - Ergänzungen

### DIFF
--- a/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
+++ b/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
@@ -42,10 +42,10 @@ auch die CSS-Pixelhöhe und -breite (in einem Tooltip des spezifischen Elements)
 der sich überlappenden Elemente angezeigt.
 
 * Eine Alternative zur Überprüfung der Zielgröße ist die Chrome Extension https://chromewebstore.google.com/detail/halfaccessible-accessibil/kofnlhenkilpdacklecdifdfigomanje?pli=1[Accessiblity Toolkit von HalfAccessible].
-** Nach Installation und Aufruf der Erweiterung erscheitn ein Popup. Hier "Open Toolkit" aktivieren.
-** Im nun Angezeiten Einblendbereich unter dem Tab "Tools" die Checkbox "Target Size" aktivieren.
-** Ziele mittels Tabben durchlaufen oder mit der MAus überfahren. Es wird angetzeigt, ob das Ziel die Anforderung erfüllt ("PASS") oder ggf. nu über den Abstand erfüllt ("REVIEW").
-** Prüfen, ob die Ziele, bei denen "REVIEW" erscheint, ausreiched Abstand zu anderen Zielen haben oder unter die Ausnahmen fallen.
+** Nach Installation und Aufruf der Erweiterung erscheint ein Popup. Hier "Open Toolkit" aktivieren.
+** Im nun angezeigten Einblendbereich unter dem Tab "Tools" die Checkbox "Target Size" aktivieren.
+** Ziele mittels Tabben durchlaufen oder mit der Maus überfahren. Es wird angezeigt, ob das Ziel die Anforderung erfüllt ("PASS") oder ggf. nur über den Abstand erfüllt ("REVIEW").
+** Prüfen, ob die Ziele, bei denen "REVIEW" erscheint, ausreiched Abstand zu anderen Zielen haben oder unter die Ausnahmen fallen (z.B. weil es Fließtextlinks sind).
 
 *	Prüfen, ob es sich bei den unterdimensionierten Elementen um Ausnahmen im Sinne des Prüfschritts handelt, denn diese werden nicht bewertet:
 ** Native Bedienelemente, deren Größe vom Benutzeragenten bestimmt sind, etwa native Checkboxen

--- a/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
+++ b/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
@@ -10,7 +10,6 @@ Der interaktive Bereich von User-Interface-Elementen (Ziel) muss für die Nutzun
 * *Gleichwertige Alternative:* Man kann mit einem anderen Bedienelement, welches die Anforderung erfüllt und sich auf derselben Seite befindet, die Funktion ausführen.
 * *Inline:* Das Ziel befindet sich in einem Satz oder die Größe des Ziels wird durch die Zeilenhöhe von umgebendem, nicht interaktiven Text eingeschränkt (z. B. ein Text-Link innerhalb eines Absatzes).
 * *Benutzeragenten:* Die Größe des Ziels wird vom Benutzeragenten bestimmt und ist von der Autorin oder dem Autor nicht verändert.
-* *Gleichwertige Alternative
 * *Essenziell:* Eine bestimmte Darstellung des Ziels ist unerlässlich oder gesetzlich vorgeschrieben.
 
 == Warum wird das geprüft
@@ -43,9 +42,12 @@ auch die CSS-Pixelhöhe und -breite (in einem Tooltip des spezifischen Elements)
 der sich überlappenden Elemente angezeigt.
 
 *	Prüfen, ob es sich bei den unterdimensionierten Elementen um Ausnahmen im Sinne des Prüfschritts handelt, denn diese werden nicht bewertet:
-  ** Native Bedienelemente, deren Größe vom Benutzeragenten bestimmt sind, etwa native Checkboxen
-  ** Ziele, deren Größe von umgebendem Text bestimmt sind (z. B. Textlinks in einem Absatz)  
-  ** Eine bestimmte Darstellung des Ziels ist unerlässlich oder gesetzlich vorgeschrieben
+
+
+** Native Bedienelemente, deren Größe vom Benutzeragenten bestimmt sind, etwa native Checkboxen
+** Ziele, deren Größe von umgebendem Text bestimmt sind (z. B. Textlinks in einem Absatz)
+** Eine bestimmte Darstellung des Ziels ist unerlässlich oder gesetzlich vorgeschrieben
+** Es gibt andere Bedienelement auf der gleichen Seite, die die Anforderung erfüllen und die gleiche Funktion ausführen
 
 === 3. Hinweise
 

--- a/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
+++ b/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
@@ -42,8 +42,6 @@ auch die CSS-Pixelhöhe und -breite (in einem Tooltip des spezifischen Elements)
 der sich überlappenden Elemente angezeigt.
 
 *	Prüfen, ob es sich bei den unterdimensionierten Elementen um Ausnahmen im Sinne des Prüfschritts handelt, denn diese werden nicht bewertet:
-
-
 ** Native Bedienelemente, deren Größe vom Benutzeragenten bestimmt sind, etwa native Checkboxen
 ** Ziele, deren Größe von umgebendem Text bestimmt sind (z. B. Textlinks in einem Absatz)
 ** Eine bestimmte Darstellung des Ziels ist unerlässlich oder gesetzlich vorgeschrieben

--- a/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
+++ b/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
@@ -10,6 +10,7 @@ Der interaktive Bereich von User-Interface-Elementen (Ziel) muss für die Nutzun
 * *Gleichwertige Alternative:* Man kann mit einem anderen Bedienelement, welches die Anforderung erfüllt und sich auf derselben Seite befindet, die Funktion ausführen.
 * *Inline:* Das Ziel befindet sich in einem Satz oder die Größe des Ziels wird durch die Zeilenhöhe von umgebendem, nicht interaktiven Text eingeschränkt (z. B. ein Text-Link innerhalb eines Absatzes).
 * *Benutzeragenten:* Die Größe des Ziels wird vom Benutzeragenten bestimmt und ist von der Autorin oder dem Autor nicht verändert.
+* *Gleichwertige Alternative
 * *Essenziell:* Eine bestimmte Darstellung des Ziels ist unerlässlich oder gesetzlich vorgeschrieben.
 
 == Warum wird das geprüft
@@ -31,8 +32,8 @@ Der Prüfschritt ist anwendbar, wenn interaktive Elemente vorhanden sind.
 * Um die CSS-Pixelgröße eines interaktiven Elements zu bestimmen, im Zweifelsfall die Inspektor-Funktion des Browsers verwenden:
   ** Mit der rechten Maustaste auf das zu testende interaktive Element klicken, und im Kontextmenü die Option „Untersuchen“ wählen. Bei den meisten Browsern wird bei dieser Methode der Elementauswahl 
 auch die CSS-Pixelhöhe und -breite (in einem Tooltip des spezifischen Elements) angezeigt.
-  ** Im Panel "Berechnet" des Inspektors werden ebenfalls die Werte für Höhe und Breite des ausgewählten Elements sowie andere berechneten CSS-Eigenschaften angezeigt, um etwa den Abstand der Elemente 
-zu ermitteln (`margin`, `padding`).
+  ** Im Panel "Layout" des Inspektors werden  die Werte für Höhe und Breite des ausgewählten Elements sowie zusätzliche Werte für die CSS-Eigenschaften `padding`, `border` und `margin` angezeigt. Sowohl `padding` als auch `border` gehören zur Zielgröße dazu, selbst wenn sie grafisch nicht sichtbar sind, denn reagieren sie auf Pointer-Aktivierung.
+  ** Im Panel "Berechnet" des Inspektors werden ebenfalls die Werte für Höhe und Breite des ausgewählten Elements sowie andere berechneten CSS-Eigenschaften angezeigt.
 
 * Das Bookmarklet https://html5accessibility.com/stuff/2023/08/28/quick-and-very-dirty-target-size-checker/[Target Size] kann unterstützend hinzugezogen werden:
   ** Es identifiziert interaktive Elemente, errechnet dessen Mittelpunkt und zeichnet einen halbtransparenten Kreis von 24×24 Pixeln um den Mittelpunkt des Elements.

--- a/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
+++ b/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
@@ -41,6 +41,12 @@ auch die CSS-Pixelhöhe und -breite (in einem Tooltip des spezifischen Elements)
   ** Wird festgestellt, dass ein interaktives Element ein anderes interaktives Element überlappt, wird nach Anwendung des Bookmarklets eine JavaScript-Warnung mit der Anzahl 
 der sich überlappenden Elemente angezeigt.
 
+* Eine Alternative zur Überprüfung der Zielgröße ist die Chrome Extension https://chromewebstore.google.com/detail/halfaccessible-accessibil/kofnlhenkilpdacklecdifdfigomanje?pli=1[Accessiblity Toolkit von HalfAccessible].
+** Nach Installation und Aufruf der Erweiterung erscheitn ein Popup. Hier "Open Toolkit" aktivieren.
+** Im nun Angezeiten Einblendbereich unter dem Tab "Tools" die Checkbox "Target Size" aktivieren.
+** Ziele mittels Tabben durchlaufen oder mit der MAus überfahren. Es wird angetzeigt, ob das Ziel die Anforderung erfüllt ("PASS") oder ggf. nu über den Abstand erfüllt ("REVIEW").
+** Prüfen, ob die Ziele, bei denen "REVIEW" erscheint, ausreiched Abstand zu anderen Zielen haben oder unter die Ausnahmen fallen.
+
 *	Prüfen, ob es sich bei den unterdimensionierten Elementen um Ausnahmen im Sinne des Prüfschritts handelt, denn diese werden nicht bewertet:
 ** Native Bedienelemente, deren Größe vom Benutzeragenten bestimmt sind, etwa native Checkboxen
 ** Ziele, deren Größe von umgebendem Text bestimmt sind (z. B. Textlinks in einem Absatz)

--- a/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
+++ b/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
@@ -45,7 +45,7 @@ der sich überlappenden Elemente angezeigt.
 ** Nach Installation und Aufruf der Erweiterung erscheint ein Popup. Hier "Open Toolkit" aktivieren.
 ** Im nun angezeigten Einblendbereich unter dem Tab "Tools" die Checkbox "Target Size" aktivieren.
 ** Ziele mittels Tabben durchlaufen oder mit der Maus überfahren. Es wird angezeigt, ob das Ziel die Anforderung erfüllt ("PASS") oder ggf. nur über den Abstand erfüllt ("REVIEW").
-** Prüfen, ob die Ziele, bei denen "REVIEW" erscheint, ausreiched Abstand zu anderen Zielen haben oder unter die Ausnahmen fallen (z.B. weil es Fließtextlinks sind).
+** Prüfen, ob die Ziele, bei denen "REVIEW" erscheint, ausreichend Abstand zu anderen Zielen haben oder unter die Ausnahmen fallen (z.B. weil es Fließtextlinks sind).
 
 *	Prüfen, ob es sich bei den unterdimensionierten Elementen um Ausnahmen im Sinne des Prüfschritts handelt, denn diese werden nicht bewertet:
 ** Native Bedienelemente, deren Größe vom Benutzeragenten bestimmt sind, etwa native Checkboxen

--- a/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
+++ b/Prüfschritte/de/9.2.5.8 Zielgröße (Minimum).adoc
@@ -45,7 +45,7 @@ der sich überlappenden Elemente angezeigt.
 ** Native Bedienelemente, deren Größe vom Benutzeragenten bestimmt sind, etwa native Checkboxen
 ** Ziele, deren Größe von umgebendem Text bestimmt sind (z. B. Textlinks in einem Absatz)
 ** Eine bestimmte Darstellung des Ziels ist unerlässlich oder gesetzlich vorgeschrieben
-** Es gibt andere Bedienelement auf der gleichen Seite, die die Anforderung erfüllen und die gleiche Funktion ausführen
+** Es gibt ein anderes Bedienelement für die gleiche Funktion, welches die Anforderung erfüllt und sich auf derselben Seite befindet
 
 === 3. Hinweise
 


### PR DESCRIPTION
* Ergänzung Prüfanleitung: Layout-Panel des Inspektors
* Erklärung, dass `padding` und `border` zur Zielgröße dazugehört