### PR TITLE
9.2.4.7 Aktuelle Position des Fokus deutlich - Entfernung des Bezugs auf Hervorhebung bei Mausnutzung

### DIFF
--- a/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
+++ b/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
@@ -15,14 +15,6 @@ Für Tastaturnutzende ist es wichtig, zu sehen, wo sich der Tastaturfokus
 gerade befindet, welcher Link also ausgelöst wird, wenn sie die Enter-Taste
 drücken.
 
-Viele Webseiten erleichtern Mausnutzenden die Bedienung, indem sie darauf
-reagieren, dass der Mauszeiger sich über einem Link befindet.
-Dann ändert sich zum Beispiel die Text- oder Hintergrundfarbe oder der
-Linktext wird unterstrichen.
-Diese Unterstützung soll auch für Tastaturnutzende funktionieren.
-Webseiten sollen sie gegenüber den zahlreicheren Mausnutzenden nicht
-benachteiligen.
-
 Die vom Browser vorgesehene Kennzeichnung des Tastaturfokus hebt sich von
 dunklen Seitenhintergründen meist nicht so gut ab.
 Das muss dann durch eine entsprechende Gestaltung ausgeglichen werden.

--- a/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
+++ b/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
@@ -54,7 +54,7 @@ ifndef::env_embedded[]
   <<9.2.1.1 Ohne Maus nutzbar.adoc#,9.2.1.1 Ohne Maus nutzbar>>
 endif::env_embedded[]
   nicht erfüllt!
-* Grundsätzlich hat sich die Standard-Hervorhebung des Tastaturfokus im Browser bei fehlender Gestaltung durch Autoren in den letzten Jahren verbessert. Abhängig von Betriebssystem und Browser, der Hintergrundfarbe und anderen Aspekten des Designs ist die Standar-Hervorhebung der Browser in manchen Fällen jedoch nicht gut sichtbar. Eine gezielte Gestaltung in CSS, z.B. über die `:focus` Pseudo-Klasse, stellt sicher, dass der Tastaturfokus immer gut sichtbar ist.
+* Grundsätzlich hat sich die Standard-Hervorhebung des Tastaturfokus im Browser bei fehlender Gestaltung durch Autoren in den letzten Jahren verbessert. Abhängig von Betriebssystem und Browser, der Hintergrundfarbe und anderen Aspekten des Designs ist die Standard-Hervorhebung der Browser in manchen Fällen jedoch nicht gut sichtbar. Eine gezielte Gestaltung in CSS, z.B. über die `:focus` Pseudo-Klasse, stellt sicher, dass der Tastaturfokus immer gut sichtbar ist.
 
 === 4. Bewertung
 

--- a/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
+++ b/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
@@ -4,11 +4,8 @@ include::include/attributes.adoc[]
 
 == Was wird geprüft?
 
-Der Tastaturfokus soll mindestens genau so deutlich hervorgehoben werden wie
-der Mausfokus.
-
-Bei Links, die _nicht_ auf den Mauszeiger reagieren, soll der Tastaturfokus
-sich zumindest deutlich von der ausgewählten Hintergrundfarbe abheben.
+Der Tastaturfokus soll deutlich hervorgehoben werden. Wenn Autoren keine eigene Fokushervorhebung umsetzen, darf die Standardhervorhebung durch den Browser nicht über CSS unterdrückt werden.
+Der Kontrast der Fokushervorhebung (z.B. Fokusrahmen um Elemente, Unterstreichung, Farbumkehr) zum nicht-fokussierten Zustand muss mindestens 3:1 betragen.
 
 Versteckte Sprunglinks sollen bei Fokuserhalt eingeblendet werden.
 

--- a/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
+++ b/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
@@ -54,7 +54,7 @@ ifndef::env_embedded[]
   <<9.2.1.1 Ohne Maus nutzbar.adoc#,9.2.1.1 Ohne Maus nutzbar>>
 endif::env_embedded[]
   nicht erfüllt!
-* Grundsätzlich hat sich die Standard-Hervorhebung des Tastaturfokus im Browser bei fehlender Gestaltung durch Autoren in den letzten Jahren verbessert. Abhängig von Betriebssystem und Browser, der Hintergrundgfarbe und anderen Aspekten des Designs ist die Standarhervorhebung in manchen Fällen jedoch nicht gut sichtbar. Eine gezielte Gestaltung stellt sicher, dass der Tastaturfokus immer gut sichtbar ist.
+* Grundsätzlich hat sich die Standard-Hervorhebung des Tastaturfokus im Browser bei fehlender Gestaltung durch Autoren in den letzten Jahren verbessert. Abhängig von Betriebssystem und Browser, der Hintergrundfarbe und anderen Aspekten des Designs ist die Standar-Hervorhebung der Browser in manchen Fällen jedoch nicht gut sichtbar. Eine gezielte Gestaltung in CSS, z.B. über die `:focus` Pseudo-Klasse, stellt sicher, dass der Tastaturfokus immer gut sichtbar ist.
 
 === 4. Bewertung
 

--- a/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
+++ b/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
@@ -12,12 +12,8 @@ Versteckte Sprunglinks sollen bei Fokuserhalt eingeblendet werden.
 == Warum wird das geprüft?
 
 Für Tastaturnutzende ist es wichtig, zu sehen, wo sich der Tastaturfokus
-gerade befindet, welcher Link also ausgelöst wird, wenn sie die Enter-Taste
-drücken.
-
-Die vom Browser vorgesehene Kennzeichnung des Tastaturfokus hebt sich von
-dunklen Seitenhintergründen meist nicht so gut ab.
-Das muss dann durch eine entsprechende Gestaltung ausgeglichen werden.
+gerade befindet, also welcher Link oder Schalter ausgelöst wird, wenn sie die Enter-Taste
+drücken, oder welches Eingabefeld oder andere Formularelement gerade den Fokus hat.
 
 == Wie wird geprüft?
 
@@ -58,6 +54,7 @@ ifndef::env_embedded[]
   <<9.2.1.1 Ohne Maus nutzbar.adoc#,9.2.1.1 Ohne Maus nutzbar>>
 endif::env_embedded[]
   nicht erfüllt!
+* Grundsätzlich hat sich die Standard-Hervorhebung des Tastaturfokus im Browser bei fehlender Gestaltung durch Autoren in den letzten Jahren verbessert. Abhängig von Betriebssystem und Browser, der Hintergrundgfarbe und anderen Aspekten des Designs ist die Standarhervorhebung in manchen Fällen jedoch nicht gut sichtbar. Eine gezielte Gestaltung stellt sicher, dass der Tastaturfokus immer gut sichtbar ist.
 
 === 4. Bewertung
 


### PR DESCRIPTION
Was wird geprüft:
* Löschung des Bezugs auf die Sichtbarkeit des Mausfokus (dass der Tastaturfokus mindestens so deutlich sein soll wie der Mausfokus, wird in den WCAG nicht verlangt)
* Hinweis, dass Tastaturfokus nicht aktiv unterdrückt werden darf
* Hinweis auf die Kontrastanforderung von 3:1 für die Fokushervorhebung.

Warum wird das geprüft:
* Löschung des Vergleiches mit Hervorhebung bei Mausnutzung
* Anpassung des Vergleichs mit Standard-Hervorhebung

Hinweise:
* Neuer Hinweis auf  Standard-Hervorhebung durch Browser 

Anwortet auf Issue https://github.com/BIK-BITV/BIK-Web-Test/issues/347