### PR TITLE
9.2.4.3 Schlüssige Reihenfolge bei der Tastaturbedienung: Verdeutlichung in der Abgrenzung zwischen 9.2.4.3 und 9.2.4.7

### DIFF
--- a/Prüfschritte/de/9.2.4.3 Schlüssige Reihenfolge bei der Tastaturbedienung.adoc
+++ b/Prüfschritte/de/9.2.4.3 Schlüssige Reihenfolge bei der Tastaturbedienung.adoc
@@ -98,7 +98,7 @@ bzw. Auswahllisten heraus bzw. durch erläuternde Texte oder Hilfefunktionen deu
 ==== Nicht voll erfüllt
 
 * Die Tabulatorreihenfolge ist nicht schlüssig, sie weicht ohne nachvollziehbaren Grund von der visuellen Anordnung ab oder der
-  Tastaturfokus ist über mehr als drei aufeinanderfolgende Stationen im Browserfenster nicht sichtbar.
+  Tastaturfokus durchläuft mehr als drei aufeinanderfolgende, nicht-sichtbare Stationen.
 * Pseudofenster, die außerhalb der normalen Quellcodereihenfolge, also etwa am Seitenende, eingefügt werden, erhalten nicht unmittelbar oder beim nächsten Tabben den Fokus.
 * Beim Schließen von Pseudofenstern wird der Fokus nicht auf das auslösende Element zurückgesetzt.
 
@@ -124,7 +124,7 @@ ifdef::env_embedded[9.2.4.7 "Aktuelle Position des Fokus deutlich".]
 ifndef::env_embedded[]
   <<9.2.4.7 Aktuelle Position des Fokus deutlich.adoc#,9.2.4.7 Aktuelle
   Position des Fokus deutlich>>.
-endif::env_embedded[]
+endif::env_embedded[]. Es geht somit in Prüfschritt 9.2.4.7 vor allem darum, dass der Fokus nicht unterdrückt bzw. deaktiviert wird, während es in diesem Prüfschritt 9.2.4.3 darum geht, ob die Elemente, die den Fokus erhalten, überhaupt sichtbar sind, oder durch visuelles Verstecken der Fokus nicht mehr aufffindbar ist, weil das Element selbst visuell versteckt wurde.
 * Geprüft wird hier die richtige *Position* eingeblendeter oder eingefügter
   Inhalte.
 Ob diese Inhalte selbst sinnvoll sind, wird in anderen Prüfkriterien wie

--- a/Prüfschritte/de/9.2.4.3 Schlüssige Reihenfolge bei der Tastaturbedienung.adoc
+++ b/Prüfschritte/de/9.2.4.3 Schlüssige Reihenfolge bei der Tastaturbedienung.adoc
@@ -124,7 +124,7 @@ ifdef::env_embedded[9.2.4.7 "Aktuelle Position des Fokus deutlich".]
 ifndef::env_embedded[]
   <<9.2.4.7 Aktuelle Position des Fokus deutlich.adoc#,9.2.4.7 Aktuelle
   Position des Fokus deutlich>>.
-endif::env_embedded[]. Es geht somit in Prüfschritt 9.2.4.7 vor allem darum, dass der Fokus nicht unterdrückt bzw. deaktiviert wird, während es in diesem Prüfschritt 9.2.4.3 darum geht, ob die Elemente, die den Fokus erhalten, überhaupt sichtbar sind, oder durch visuelles Verstecken der Fokus nicht mehr aufffindbar ist, weil das Element selbst visuell versteckt wurde.
+endif::env_embedded[]. In Prüfschritt 9.2.4.7 geht es vor allem darum, dass der Fokus nicht unterdrückt bzw. deaktiviert wird, während es in diesem Prüfschritt 9.2.4.3 unter anderem auch darum geht, dass die Elemente, die den Fokus erhalten, bei Fokuserhalt selbst sichtbar sind. Wenn Elemente visuell versteckt werden, sind sie bei Fokuserhalt für Tastaturnutzende nicht mehr wahrnehmbar. Dadurch wird die Nachvollziehbarkeit der Tabreihenfolge erschwert.
 * Geprüft wird hier die richtige *Position* eingeblendeter oder eingefügter
   Inhalte.
 Ob diese Inhalte selbst sinnvoll sind, wird in anderen Prüfkriterien wie


### PR DESCRIPTION
Mit diesem PR soll der bestehende Text des Prüfschritts [9.2.4.3](https://bitvtest.de/pruefschritt/bitv-20-web/bitv-20-web-9-2-4-3-schluessige-reihenfolge-bei-der-tastaturbedienung) verdeutlicht werden in der Abgrenzung zu Prüfschritt [9.2.4.7](https://bitvtest.de/pruefschritt/bitv-20-web/bitv-20-web-9-2-4-7-aktuelle-position-des-fokus-deutlich) hinsichtlich der enthaltenen Phrase der "Stationen".

_Für die Vergabe von Labels habe ich keine Berechtigung, sodass ich rein die Änderungsvorschläge und die Beschreibung beigefügt habe._