### PR TITLE
9.2.4.4 Aussagekräftige Linktexte: Fix eines fehlerhaften Links

### DIFF
--- a/Prüfschritte/de/9.2.4.4 Aussagekräftige Linktexte.adoc
+++ b/Prüfschritte/de/9.2.4.4 Aussagekräftige Linktexte.adoc
@@ -87,9 +87,9 @@ Das ist der Fall, wenn das Dateiformat in
 einer Grafik, im Linktext oder im title-Text des Links angegeben wird.
 
 Ist die Grafik, die Auskunft über das Dateiformat gibt, nicht im Link eingebunden (z. B. unverlinkt dem Link vorangestellt), so wird dies in Prüfschritt 
-ifdef::env_embedded[11.1.1.1b "Alternativtexte für Grafiken und Objekte"]
+ifdef::env_embedded[9.1.1.1b "Alternativtexte für Grafiken und Objekte"]
 ifndef::env_embedded[]
-  <<11.1.1.1a Alternativtexte für Grafiken und Objekte.adoc#,11.1.1.1b
+  <<9.1.1.1b Alternativtexte für Grafiken und Objekte.adoc#,9.1.1.1b
   Alternativtexte für Grafiken und Objekte>>
 endif::env_embedded[]
 geprüft.


### PR DESCRIPTION
Hallo BITV!

Hier war der nicht existierende Prüfschritt 1.1.1.1b verlinkt

<img width="881" alt="image" src="https://github.com/BIK-BITV/BIK-Web-Test/assets/67189/663c8b05-0645-4c9c-a93a-9e9b8a5d53e4">

Nach dem Kontext muss hier auf "9.1.1.1b Alternativtexte für Grafiken und Objekte" verlinkt werden

LG & Schönes Wochenende 

Bastian
