### PR TITLE
9.2.4.1 Bereiche überspringbar - Hinzufügung Sprunglinks-Fokussierung…

### DIFF
--- a/Prüfschritte/de/9.2.4.1 Bereiche überspringbar.adoc
+++ b/Prüfschritte/de/9.2.4.1 Bereiche überspringbar.adoc
@@ -138,7 +138,8 @@ oder Änderungsdatum stehen.
 ==== Hinweis zu Sprunglinks und Document Landmarks
 
 Das Fehlen von Sprunglinks und die Nichtverwendung von WAI-ARIA Document
-Landmarks werden nicht negativ bewertet.
+Landmarks werden nicht grundsätzlich negativ bewertet. Es hängt vom Inhalt und von der Komplextät der Seiten ab, 
+of ein Mechanismus zum Überspringen von Bereichen erforderlich ist.
 
 ==== Hinweis zu mehrfach verwendeten Landmarks bzwHTML5-Elemente für Bereiche
 

--- a/Prüfschritte/de/9.2.4.1 Bereiche überspringbar.adoc
+++ b/Prüfschritte/de/9.2.4.1 Bereiche überspringbar.adoc
@@ -90,7 +90,7 @@ erfüllt sind:
 * Sprunglinks sind entweder permanent sichtbar oder werden bei Fokuserhalt
   eingeblendet
 * Sprunglinks am Seitenbeginn sind die ersten fokussierbaren Elemente der
-  Tabreihenfolge
+  Tabreihenfolge (oder ggf. die ersten nach einem Cookie-Bannner oder Dialog)
 * Sprunglinks zum Überspringen von Inhaltsblöcken sind das letzte
   fokussierbare Element vor dem zu überspringenden Inhaltsblock oder dessen
   erster Link

--- a/Prüfschritte/de/9.2.4.1 Bereiche überspringbar.adoc
+++ b/Prüfschritte/de/9.2.4.1 Bereiche überspringbar.adoc
@@ -139,7 +139,7 @@ oder Änderungsdatum stehen.
 
 Das Fehlen von Sprunglinks und die Nichtverwendung von WAI-ARIA Document
 Landmarks werden nicht grundsätzlich negativ bewertet. Es hängt vom Inhalt und von der Komplextät der Seiten ab, 
-of ein Mechanismus zum Überspringen von Bereichen erforderlich ist.
+ob ein Mechanismus zum Überspringen von Bereichen erforderlich ist.
 
 ==== Hinweis zu mehrfach verwendeten Landmarks bzwHTML5-Elemente für Bereiche
 


### PR DESCRIPTION
Adressiert #454 - wenn ein Cookiedialog vorhanden ist, der am Seitenbeginn fokussiert wird, werden die Sprunglinks danach fokussiert.