### PR TITLE
9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar - Beispiel Datum: Ergänzung der Gruppenbeschriftung

### DIFF
--- a/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
+++ b/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
@@ -83,7 +83,7 @@ In diesem Fall sollen Elemente mit einem erklärenden
 ``title``-Attribut versehen werden.
 Beispiel: In einem Formular werden für die
 Eingabe eines Datums drei Auswahllisten angeboten (Tag, Monat und Jahr).
-Die drei Auswahllisten haben eine gemeinsame Gruppenbeschriftung "Datum" welche beispielsweise mit `fieldset` und `legend` umgesetzt wurde.
+Die drei Auswahllisten haben eine gemeinsame Gruppenbeschriftung "Datum" welche beispielsweise mit `fieldset` und `legend` umgesetzt ist.
 Die Auswahllisten für Tag, Monat und Jahr sind mit einem erklärenden
 ``title``-Attribut versehen.
 Alternativ kann in diesem Fall die Beschriftung auch mit Hilfe von

--- a/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
+++ b/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
@@ -83,7 +83,7 @@ In diesem Fall sollen Elemente mit einem erklärenden
 ``title``-Attribut versehen werden.
 Beispiel: In einem Formular werden für die
 Eingabe eines Datums drei Auswahllisten angeboten (Tag, Monat und Jahr).
-Die drei Auswahllisten haben eine gemeinsame Beschriftung: Datum.
+Die drei Auswahllisten haben eine gemeinsame Gruppenbeschriftung "Datum" welche beispielsweise mit `fieldset` und `legend` umgesetzt wurde.
 Die Auswahllisten für Tag, Monat und Jahr sind mit einem erklärenden
 ``title``-Attribut versehen.
 Alternativ kann in diesem Fall die Beschriftung auch mit Hilfe von


### PR DESCRIPTION
- Abschnitt 3.2, Beispiel Datum mit 3 Auswahllisten: Text ergänzt (... "Datum" als Gruppenbeschriftung beispielsweise mit `fieldst` und `legend`. ...)
