### PR TITLE
9.2.5.7 Ziehbewegungen - Slider-Bezug beim letzen Beispiel in der Prüfschrittbeschreibung entfernt

### DIFF
--- a/Prüfschritte/de/9.2.5.7 Ziehbewegungen.adoc
+++ b/Prüfschritte/de/9.2.5.7 Ziehbewegungen.adoc
@@ -26,7 +26,7 @@ Der Prüfschritt ist anwendbar, wenn Funktionen mit Hilfe von Ziehbewegungen (Zi
 
   * Nach Aktivierung eines Elements über einfache Zeigeraktion erlaubt ein Aktions-Menü die Auswahl des Zielorts.
   * Nach Aktivierung eines Elements über einfache Zeigeraktion erscheinen im Kontext des Elements Pfeile, die ein schrittweises Verschieben des Elements erlauben.
-  * Bei Schiebereglern gibt es die Möglichkeit numerischer Eingaben des Wertes über die (virtuelle) Tastatur.
+  * Die Funktion kann auch über numerische Eingaben eines Wertes über die virtuelle Tastatur ausgeführt werden.
 
 === 3. Hinweise
 

--- a/Prüfschritte/de/9.2.5.7 Ziehbewegungen.adoc
+++ b/Prüfschritte/de/9.2.5.7 Ziehbewegungen.adoc
@@ -26,6 +26,7 @@ Der Prüfschritt ist anwendbar, wenn Funktionen mit Hilfe von Ziehbewegungen (Zi
 
   * Nach Aktivierung eines Elements über einfache Zeigeraktion erlaubt ein Aktions-Menü die Auswahl des Zielorts.
   * Nach Aktivierung eines Elements über einfache Zeigeraktion erscheinen im Kontext des Elements Pfeile, die ein schrittweises Verschieben des Elements erlauben.
+  * Ein einfaches Tippen oder Klicken auf die gewünschte Position eines Schiebereglers auf der Achse (groove) führt zum Versetzen der Position des Reglerknopfes (thumb).
   * Die Funktion kann auch über numerische Eingaben eines Wertes über die virtuelle Tastatur ausgeführt werden.
 
 === 3. Hinweise

--- a/Prüfschritte/de/9.2.5.7 Ziehbewegungen.adoc
+++ b/Prüfschritte/de/9.2.5.7 Ziehbewegungen.adoc
@@ -50,7 +50,7 @@ Für das Ausführen einer Funktion mit Ziehbewegung gibt es keine alternative Me
 === Abgrenzung zu anderen Prüfschritten
 
 * Prüfschritt 2.1.1 Ohne Maus nutzbar prüft, ob alle Funktionen auch mit der Tastatur bedienbar sind. 
-* Prüfschritt 2.5.7 Ziehbewegungen prüft hingegen, ob die Bedienung mit einer Zeigereingabe möglich ist (zum Beispiel Klicken oder Tippen), denn eine funktionierende Tastaturbedienung bedeutet nicht zwangsläufig, 
+* Prüfschritt 2.5.7 Ziehbewegungen prüft hingegen, ob die Bedienung mit einer einfachen Zeigereingabe oder eine Folge von solchen einfachen Eingaben möglich ist (zum Beispiel Klicken oder Tippen), denn eine funktionierende Tastaturbedienung bedeutet nicht zwangsläufig, 
 dass die Ziehfunktion auch über einfache Zeigeraktionen ausführbar ist.
 * Prüfschritt 2.5.7 bezieht sich auf *Ziehbewegungen* (nur der Anfangs- und Endpunkt der Bewegung von Bedeutung, der Pfad dazwischen ist beliebig). Prüfschritt 2.5.1 Alternativen für komplexe Zeigergesten behandelt *Zeigergesten,* 
 d.h. pfadbasierte Gesten (eine bestimmte Richtung, d. h. ein bestimmter Pfad ist für die Ausführung nötig) und *Mehrpunktgesten* (z. B. Zwei-Finger-Spreizgeste).


### PR DESCRIPTION
Anpassung der Prüfschrittanleitung, bzgl. 3. Beispiel (Schieberegler soll nicht im Vordergrund stehen), siehe https://github.com/BIK-BITV/BIK-Web-Test/issues/448
