### PR TITLE
9.2.2.1 Zeitbegrenzungen anpassbar - Anwendbarkeit überarbeitet (Beschränkung auf Transaktionen entfernt)

### DIFF
--- a/Prüfschritte/de/9.2.2.1 Zeitbegrenzungen anpassbar.adoc
+++ b/Prüfschritte/de/9.2.2.1 Zeitbegrenzungen anpassbar.adoc
@@ -38,9 +38,7 @@ ist immer anwendbar.
 * Die Prüfung auf Abschaltbarkeit oder Verlängerbarkeit von Zeitbegrenzungen
 (Abschnitt
 <<2.2 Prüfung auf Abschaltbarkeit oder Verlängerbarkeit von Zeitbegrenzungen>>)
-ist nur anwendbar auf Seiten mit Transaktionen, welche üblicherweise aus
-datenschutzrechtlichen oder sicherheitsrelevanten Gründen Zeitbegrenzungen
-unterliegen (etwa beim Online-Banking oder Online-Shops).
+ist immer anwendbar.
 * Die Prüfung von Zeitbegrenzungen bei wichtigen Statusmeldungen ist immer anwendbar, wenn (oft als Ergebnis einer Interaktion) Meldungen erscheinen und nach einer Zeitspanne (meist nach wenigen Sekunden) automatisch wieder verschwinden.
 
 === 2. Prüfung


### PR DESCRIPTION
- Anwendbarkeit: Die Prüfung auf Abschaltbarkeit oder Verlängerbarkeit ist immer anwendbar (war bislang auf Transaktionen ... beschränkt). Siehe https://github.com/BIK-BITV/BIK-Web-Test/issues/469