### PR TITLE
9.1.3.1a HTML-Strukturelemente für Überschriften: FAQ ? statt .

### DIFF
--- a/Prüfschritte/de/9.1.3.1a HTML-Strukturelemente für Überschriften.adoc
+++ b/Prüfschritte/de/9.1.3.1a HTML-Strukturelemente für Überschriften.adoc
@@ -182,7 +182,6 @@ Ihr Nutzen ist fraglich, es kann also auch sinnvoll sein, mehrere
 Überschriften auf derselben Seite mit `h1` auszuzeichnen.
 
 === Warum sind die Anforderungen des Prüfschritts so allgemein gehalten?
-Es gibt doch klare formale Vorgaben für die richtige Strukturierung durch Überschriften!
 
 Formale Regeln für die Strukturierung durch Überschriften sind sinnvoll und
 sie können nützlich sein.

--- a/Prüfschritte/de/9.1.3.1a HTML-Strukturelemente für Überschriften.adoc
+++ b/Prüfschritte/de/9.1.3.1a HTML-Strukturelemente für Überschriften.adoc
@@ -181,7 +181,7 @@ entweder nichtssagend oder sie zählt einfach die beiden Themen auf.
 Ihr Nutzen ist fraglich, es kann also auch sinnvoll sein, mehrere
 Überschriften auf derselben Seite mit `h1` auszuzeichnen.
 
-=== Warum sind die Anforderungen des Prüfschritts so allgemein gehalten.
+=== Warum sind die Anforderungen des Prüfschritts so allgemein gehalten?
 Es gibt doch klare formale Vorgaben für die richtige Strukturierung durch Überschriften!
 
 Formale Regeln für die Strukturierung durch Überschriften sind sinnvoll und


### PR DESCRIPTION
A question should end with an `?` not with a `.`

Die Formatierung der ergänzenden Aussage `Es gibt doch klare formale Vorgaben für die richtige Strukturierung durch Überschriften!` könnte man ggf. optisch auch anders trennen, hat mMn keine inhaltliche Relevanz und könnte eventuell komplett entfernt werden. Die visuelle Darstellung lässt suggerieren, dass dieser Part ein Teil der Antwort und nicht der Frage ist.
<img width="936" alt="image" src="https://github.com/user-attachments/assets/28453043-210e-41b4-b1b1-99a0bf5255f5" />

