### PR TITLE
9.1.4.1 Ohne Farben nutzbar: Fehlendes Satzzeichen in FAQ

### DIFF
--- a/Prüfschritte/de/9.1.4.1 Ohne Farben nutzbar.adoc
+++ b/Prüfschritte/de/9.1.4.1 Ohne Farben nutzbar.adoc
@@ -194,7 +194,7 @@ https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html
 
 == Fragen zu diesem Prüfschritt
 
-=== Häufig werden besuchte Links in einer anderen Farbe dargestellt Fällt das auch unter diesen Prüfschritt?
+=== Häufig werden besuchte Links in einer anderen Farbe dargestellt. Fällt das auch unter diesen Prüfschritt?
 
 Die Unterscheidung besuchter und nicht besuchter Links ist hilfreich. Der Benutzer kann gleich sehen, welche Seiten er schon besucht hat. Ideal wäre es daher, wenn besuchte Links zum Beispiel zusätzlich durch eine andere Unterstreichung markiert würden.
 


### PR DESCRIPTION
In den „FAQ“ wird innerhalb der Frage mit einem Satz begonnen, dessen Satzzeichen `.` fehlt. 

Man könnte die Frage aber ohne eine Aussage umformulieren etwa wie:
> Werden besuchte Links in einer anderen Farbe auch durch diesen Prüfschritt abgedeckt?

Da das aber eventuell ein zu starker Eingriff in die textliche Struktur ist, habe ich hier nur den fehlenden Punkt ersetzt, da dies meiner Einschätzung nach geändert werden sollte. Die Änderung des Textes empfinde ich als optional und würde ich den Author*innen überlassen. 