### PR TITLE
9.1.4.12 Textabstände anpassbar: Ergänzung der Ausname "Auswahliste" (select > option) (version:minor)

### DIFF
--- a/Prüfschritte/de/9.1.4.12 Textabstände anpassbar.adoc
+++ b/Prüfschritte/de/9.1.4.12 Textabstände anpassbar.adoc
@@ -44,7 +44,7 @@ der nicht über eine Grafik bereitgestellt wird).
   oder den Verlust von Funktionalität kommt.
   
 === 3. Hinweise
-* Die Anforderung ist nicht anwendbar auf HTML-Standardelemente wie `input type="file"` oder Optinoen einer Ausklappliste (`<select>`). Die CSS-Anpassungen haben keine Auswirkung auf diese Elemente.
+* Die Anforderung ist nicht anwendbar auf HTML-Standardelemente wie `input type="file"` oder Optionen einer Ausklappliste (`<select>`). Die CSS-Anpassungen haben keine Auswirkung auf diese Elemente.
 
 === 4. Bewertung
 ==== Erfüllt:

--- a/Prüfschritte/de/9.1.4.12 Textabstände anpassbar.adoc
+++ b/Prüfschritte/de/9.1.4.12 Textabstände anpassbar.adoc
@@ -44,7 +44,7 @@ der nicht über eine Grafik bereitgestellt wird).
   oder den Verlust von Funktionalität kommt.
   
 === 3. Hinweise
-* Die Anforderung ist nicht anwendbar auf HTML-Standardelemente wie `input type="file"` oder https://handreichungen.bfit-bund.de/barrierefreie-uie/ausklappliste.html[Optinoen einer Ausklappliste]. Die CSS-Anpassungen haben keine Auswirkung auf diese Elemente.
+* Die Anforderung ist nicht anwendbar auf HTML-Standardelemente wie `input type="file"` oder Optinoen einer Ausklappliste (`<select>`). Die CSS-Anpassungen haben keine Auswirkung auf diese Elemente.
 
 === 4. Bewertung
 ==== Erfüllt:

--- a/Prüfschritte/de/9.1.4.12 Textabstände anpassbar.adoc
+++ b/Prüfschritte/de/9.1.4.12 Textabstände anpassbar.adoc
@@ -44,7 +44,7 @@ der nicht über eine Grafik bereitgestellt wird).
   oder den Verlust von Funktionalität kommt.
   
 === 3. Hinweise
-* Die Anforderung ist nicht anwendbar ist auf Elemente wie `input type="file"`, auf die CSS-Anpassungen keine Auswirkung haben.
+* Die Anforderung ist nicht anwendbar auf HTML-Standardelemente wie `input type="file"` oder https://handreichungen.bfit-bund.de/barrierefreie-uie/ausklappliste.html[Optinoen einer Ausklappliste]. Die CSS-Anpassungen haben keine Auswirkung auf diese Elemente.
 
 === 4. Bewertung
 ==== Erfüllt:


### PR DESCRIPTION
- Hinweis und Ausnahme deutlicher gemacht.
- HTML-Standardelemente wie file-upload und Ausklapplisten (select > option) sind ausgenommen.
- Verlinkung zur Definition einer Ausklappliste