### PR TITLE
9.2.4.7 Aktuelle Position des Fokus deutlich - Hinweis zu Kontrastanforderung bei "Was wird geprüft" entfernt

### DIFF
--- a/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
+++ b/Prüfschritte/de/9.2.4.7 Aktuelle Position des Fokus deutlich.adoc
@@ -5,7 +5,7 @@ include::include/attributes.adoc[]
 == Was wird geprüft?
 
 Der Tastaturfokus soll deutlich hervorgehoben werden. Wenn Autoren keine eigene Fokushervorhebung umsetzen, darf die Standardhervorhebung durch den Browser nicht über CSS unterdrückt werden.
-Der Kontrast der Fokushervorhebung (z.B. Fokusrahmen um Elemente, Unterstreichung, Farbumkehr) zum nicht-fokussierten Zustand muss mindestens 3:1 betragen.
+In diesem Prüfschritt wird lediglich geprüft, ob eine Fokushervorhebung sichtbar ist – nicht, ob sie ausreichend kontrastreich ist.
 
 Versteckte Sprunglinks sollen bei Fokuserhalt eingeblendet werden.
 


### PR DESCRIPTION
- "Was wird geprüft": Hinweis auf Kontrastprüfung der Fokushervorhebung in diesem Prüfschritt entfernt. Wird seit dem vorletzten Release entsprechend WCAG bei 9.1.4.11 geprüft. In der Prüfanleitung wird die Abgrenzung bereits richtig dargestellt. 
