### PR TITLE
9.2.5.3 Sichtbare Beschriftung Teil des zugänglichen Namens - Ergänzung

### DIFF
--- a/Prüfschritte/de/9.2.5.3 Sichtbare Beschriftung Teil des zugänglichen Namens.adoc
+++ b/Prüfschritte/de/9.2.5.3 Sichtbare Beschriftung Teil des zugänglichen Namens.adoc
@@ -70,6 +70,8 @@ Der zugängliche Name des Bedienelements kann zusätzlichen Text enthalten, aber
 die Zeichenkette der Beschriftung sollte in der gleichen Form in der
 Zeichenkette des zugänglichen Namens enthalten sein.
 
+In Fällen, wo Bedienelemente keinen zugänglichen Namen haben, aber eine zugeordnete sichtbare Beschriftung, z.B. ein Textfeld mit einer nicht programmatisch verknüpften Beschriftung, ist nicht nur der Prüfschritt 9.1.3.1h "Info und Beziehungen - Beschriftung von Formularelementen programmatisch ermittelbar", sondern auch dieser Prüfschritt nicht erfüllt.
+
 === 4. Bewertung
 
 Der Prüfschritt ist erfüllt, wenn der Beschriftungstext in der gleichen Form


### PR DESCRIPTION
Ergänzung eines Hinweises, dass bei Bedienelementen ohne zugänglichen Namen mit sichtbar zugeordneter Beschriftung, etwa bei Textfeldern mit Beschriftung, die nicht programmatisch verknüpft oder anderweitig prgrammatisch bereitgestellt ist, nicht nur 9.1.3.1h, sondern auch 9.2.5.3 nicht erfüllt ist.