### PR TITLE
9.1.3.1g Kein Strukturmarkup für Layouttabellen: id entfernt

### DIFF
--- a/Prüfschritte/de/9.1.3.1g Kein Strukturmarkup für Layouttabellen.adoc
+++ b/Prüfschritte/de/9.1.3.1g Kein Strukturmarkup für Layouttabellen.adoc
@@ -21,7 +21,7 @@ Firefox] aufrufen.
 https://www.bitvtest.de/bitv_test/das_testverfahren_im_detail/werkzeugliste.html#tablesbm[
 Tables bookmarklet] aufrufen. Tabellen-Auszeichnungen werden jetzt angezeigt.
 * Prüfen, ob strukturelle Auszeichnungen (``th``, ``caption``, ``summary``,
-``headers``, ``id``) in Layouttabellen vermieden werden.
+``headers``) in Layouttabellen vermieden werden.
 
 === 3. Hinweis
 
@@ -33,7 +33,7 @@ sind, sollten semantische Elemente nicht benutzt werden.
 ==== Nicht erfüllt
 
 * In Layouttabellen werden die Elemente `th` oder `caption` oder die Attribute
-``summary``, `headers` oder `id` verwendet.
+``summary`` oder  `headers` verwendet.
 
 == Einordnung des Prüfschritts
 


### PR DESCRIPTION
Die Verwendung von `id` in Datentabellen ist nicht grundsätzlich ein Problem (gedacht war an die Verwendung von `id` im Zusammenhang mit dem `headers`-Attribut) deswegen wurde `id` aus der Prüfanleitung zur Feststellung von semantischem Markup in Layouttabellen entfernt.

Closes #519
