### PR TITLE
9.1.3.1h Beschriftung von Formularelementen: Ergänzung Custom-Elemente

### DIFF
--- a/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
+++ b/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
@@ -14,16 +14,17 @@ Beschriftung des zugehörigen Formularelements auf anderem Weg (etwa über das
 ``aria-labelledby``-Attribut) sichergestellt sein.
 
 Werden selbstgestaltete Formularelemente eingesetzt, 
-z.B. ein `div` mit `role="textbox"` und Attribut `contenteditable="true"`, 
+z.B. ein `div` mit ``role="textbox"`` und Attribut ``contenteditable="true"``, 
 muss eine programmatisch ermittelbare Beschriftung auf anderem Wege bereitgestellt werden, 
-weil hier `label for` nicht greift: 
-z.B. mittels `aria-labelledby`-Verweis auf die sichtbare Beschriftung 
-oder den Einsatz eines `aria-label`-Attributs.
+weil hier ``label for`` nicht greift: 
+z.B. mittels ``aria-labelledby``-Verweis auf die sichtbare Beschriftung 
+oder den Einsatz eines ``aria-label``-Attributs.
 
 Ist bei Gruppen von Formularelementen eine Gruppenbeschriftung für das
 Verständnis der Beschriftung der einzelnen Formularelemente nötig, sollte die
-Verfügbarkeit sichergestellt werden (z. B. mit Hilfe von `fieldset` mit
-``legend``).
+programmatische Verfügbarkeit dieser Beschriftung sichergestellt werden, 
+z. B. mit Hilfe von ``fieldset`` mit ``legend`` bei nativen input-Elementen, 
+oder role="group" mit Gruppenbeschriftung über ``aria-labelledby``-Verweis.
 
 Visuell voneinander abgesetzte oder logisch miteinander verbundene Gruppen von
 Formularelementen sollten mit `fieldset` oder mithilfe von Überschriften

--- a/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
+++ b/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
@@ -24,7 +24,7 @@ Ist bei Gruppen von Formularelementen eine Gruppenbeschriftung für das
 Verständnis der Beschriftung der einzelnen Formularelemente nötig, sollte die
 programmatische Verfügbarkeit dieser Beschriftung sichergestellt werden, 
 z. B. mit Hilfe von ``fieldset`` mit ``legend`` bei nativen ``input``-Elementen, 
-oder role="group" mit Gruppenbeschriftung über ``aria-labelledby``-Verweis.
+oder ``role="group"`` mit Gruppenbeschriftung über ``aria-labelledby``-Verweis.
 
 Visuell voneinander abgesetzte oder logisch miteinander verbundene Gruppen von
 Formularelementen sollten mit `fieldset` oder mithilfe von Überschriften

--- a/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
+++ b/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
@@ -23,7 +23,7 @@ oder den Einsatz eines ``aria-label``-Attributs.
 Ist bei Gruppen von Formularelementen eine Gruppenbeschriftung für das
 Verständnis der Beschriftung der einzelnen Formularelemente nötig, sollte die
 programmatische Verfügbarkeit dieser Beschriftung sichergestellt werden, 
-z. B. mit Hilfe von ``fieldset`` mit ``legend`` bei nativen input-Elementen, 
+z. B. mit Hilfe von ``fieldset`` mit ``legend`` bei nativen ``input``-Elementen, 
 oder role="group" mit Gruppenbeschriftung über ``aria-labelledby``-Verweis.
 
 Visuell voneinander abgesetzte oder logisch miteinander verbundene Gruppen von

--- a/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
+++ b/Prüfschritte/de/9.1.3.1h Beschriftung von Formularelementen programmatisch ermittelbar.adoc
@@ -13,6 +13,13 @@ Sind Beschriftungen nicht mit dem ``label``-Element ausgezeichnet, soll eine
 Beschriftung des zugehörigen Formularelements auf anderem Weg (etwa über das
 ``aria-labelledby``-Attribut) sichergestellt sein.
 
+Werden selbstgestaltete Formularelemente eingesetzt, 
+z.B. ein `div` mit `role="textbox"` und Attribut `contenteditable="true"`, 
+muss eine programmatisch ermittelbare Beschriftung auf anderem Wege bereitgestellt werden, 
+weil hier `label for` nicht greift: 
+z.B. mittels `aria-labelledby`-Verweis auf die sichtbare Beschriftung 
+oder den Einsatz eines `aria-label`-Attributs.
+
 Ist bei Gruppen von Formularelementen eine Gruppenbeschriftung für das
 Verständnis der Beschriftung der einzelnen Formularelemente nötig, sollte die
 Verfügbarkeit sichergestellt werden (z. B. mit Hilfe von `fieldset` mit


### PR DESCRIPTION
Ergänzung, dass bei custom-Elementen eine programmatische Beschriftung auf anderem Wege bereitgestellt werden muss.