### PR TITLE
9.1.1.1a Alternativtexte für Bedienelemente: Typos

### DIFF
--- a/Prüfschritte/de/9.1.1.1a Alternativtexte für Bedienelemente.adoc
+++ b/Prüfschritte/de/9.1.1.1a Alternativtexte für Bedienelemente.adoc
@@ -365,8 +365,7 @@ ifndef::env_embedded[]
   <<9.4.1.2 Name-Rolle-Wert verfügbar.adoc#,9.4.1.2 Name, Rolle, Wert
   verfügbar>>
 endif::env_embedded[]
-  geprüft (s. olink:#3.2[3.2 Unterstützung von SVGs durch assistive
-  Technologien]).
+  geprüft.
 
 === Einordnung des Prüfschritts nach WCAG 2.2
 


### PR DESCRIPTION
* Entfernen eines kaputten Sprunglinks

